### PR TITLE
Improved Fox.gltf shading

### DIFF
--- a/examples/webgpu_wgsl/complex/index.html
+++ b/examples/webgpu_wgsl/complex/index.html
@@ -19,7 +19,7 @@ struct Uniforms {
     normalMatrix: mat4x4<f32>,
     lightDir: vec4<f32>,
     baseColor: vec4<f32>,
-    flags: vec4<u32>  // x: hasSkinning, y: hasTexture
+    flags: vec4<u32>  // x: hasSkinning, y: hasTexture, z: hasNormals
 };
 
 struct JointMatrices {
@@ -41,7 +41,8 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) vNormal: vec3<f32>,
     @location(1) vTexCoord: vec2<f32>,
-    @location(2) vPosition: vec3<f32>
+    @location(2) vPosition: vec3<f32>,
+    @location(3) vWorldPosition: vec3<f32>
 };
 
 @vertex
@@ -64,6 +65,7 @@ fn main(input: VertexInput) -> VertexOutput {
     
     let worldPosition = uniforms.modelMatrix * position;
     output.vPosition = worldPosition.xyz;
+    output.vWorldPosition = worldPosition.xyz;
     output.vNormal = (uniforms.normalMatrix * vec4<f32>(normal, 0.0)).xyz;
     output.vTexCoord = input.texCoord;
     output.position = uniforms.projectionMatrix * uniforms.viewMatrix * worldPosition;
@@ -91,12 +93,28 @@ struct Uniforms {
 struct FragmentInput {
     @location(0) vNormal: vec3<f32>,
     @location(1) vTexCoord: vec2<f32>,
-    @location(2) vPosition: vec3<f32>
+    @location(2) vPosition: vec3<f32>,
+    @location(3) vWorldPosition: vec3<f32>
 };
 
 @fragment
 fn main(input: FragmentInput) -> @location(0) vec4<f32> {
-    let normal = normalize(input.vNormal);
+    var normal: vec3<f32>;
+    
+    // Use interpolated normals if available, otherwise use flat shading
+    if (uniforms.flags.z == 1u) {
+        // Has normals: use interpolated normal
+        normal = normalize(input.vNormal);
+    } else {
+        // No normals: compute normal from surface derivatives for flat shading
+        // In screen space, we compute the normal using dFdx and dFdy
+        // dFdx returns the derivative of the input with respect to the screen x coordinate
+        // dFdy returns the derivative of the input with respect to the screen y coordinate
+        let ddx = dpdx(input.vWorldPosition);
+        let ddy = dpdy(input.vWorldPosition);
+        normal = normalize(cross(ddx, ddy));
+    }
+    
     let lightDir = normalize(uniforms.lightDir.xyz);
     
     let diff = max(dot(normal, lightDir), 0.0);

--- a/examples/webgpu_wgsl/complex/index.js
+++ b/examples/webgpu_wgsl/complex/index.js
@@ -393,6 +393,7 @@ async function processMesh(device, gltf, buffers, baseUrl, meshIndex, defaultTex
             baseColor,
             hasTexture,
             hasSkinning,
+            hasNormals: normals !== null,
             bbox
         });
     }
@@ -1059,6 +1060,7 @@ async function main() {
             floatView.set(ground.track.color, 68);
             uintView[72] = 0; // hasSkinning
             uintView[73] = 0; // hasTexture
+            uintView[74] = 1; // hasNormals (ground tracks have normals)
             
             device.queue.writeBuffer(ground.uniformBuffer, 0, uniforms);
             
@@ -1147,6 +1149,7 @@ async function main() {
                         floatView.set(prim.baseColor, 68); // baseColor
                         uintView[72] = prim.hasSkinning && nodeSkin ? 1 : 0; // hasSkinning
                         uintView[73] = prim.hasTexture ? 1 : 0; // hasTexture
+                        uintView[74] = prim.hasNormals ? 1 : 0; // hasNormals
                         
                         device.queue.writeBuffer(instance.uniformBuffer, 0, uniforms);
                         


### PR DESCRIPTION
This pull request enhances the WebGPU WGSL complex example by adding support for flat shading when mesh normals are not available. It introduces a new flag to indicate the presence of normals, updates the shader to compute normals dynamically if needed, and ensures the rendering pipeline can handle both cases. The changes affect both the WGSL shader code and the JavaScript logic that sets mesh properties and uniform buffers.

**Shader and rendering improvements:**

* Added a `hasNormals` flag (z component) to the `flags` field in the shader's uniform struct to indicate whether normals are provided for a mesh. [[1]](diffhunk://#diff-6703d3ea2a15adf2d70a786106fc91fbeb18772b53146b9a4e364528b4780ae2L22-R22) [[2]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR396) [[3]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR1063) [[4]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR1152)
* Updated the vertex and fragment input/output structs and logic to include and use `vWorldPosition`, enabling the fragment shader to compute normals via derivatives if normals are missing. [[1]](diffhunk://#diff-6703d3ea2a15adf2d70a786106fc91fbeb18772b53146b9a4e364528b4780ae2L44-R45) [[2]](diffhunk://#diff-6703d3ea2a15adf2d70a786106fc91fbeb18772b53146b9a4e364528b4780ae2R68) [[3]](diffhunk://#diff-6703d3ea2a15adf2d70a786106fc91fbeb18772b53146b9a4e364528b4780ae2L94-R117)

**Flat shading support:**

* Modified the fragment shader to check the `hasNormals` flag: if normals are not present, it computes the surface normal using screen-space derivatives (`dpdx`/`dpdy`) for flat shading; otherwise, it uses the interpolated normal as before.

**JavaScript pipeline updates:**

* Updated mesh processing and uniform buffer setup in `index.js` to correctly set the new `hasNormals` flag for each mesh and ensure the buffer layout matches the shader's expectations. [[1]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR396) [[2]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR1063) [[3]](diffhunk://#diff-6b0b76ae6960094b32644f00c292269dd7dcef2cf5058646943c3d958e8f052eR1152)