### PR TITLE
Add Babylon.js Lite samples

### DIFF
--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -75,43 +75,43 @@ async function init() {
     // ---- Fox debug ----
     function inspectNode(node, depth = 0) {
         const indent = "  ".repeat(depth);
-        const hasMesh = "_gpu" in node && "material" in node;
-        const gpu = node._gpu;
+        const allKeys = [];
+        for (const k in node) allKeys.push(k); // includes non-own enumerable
+        const ownKeys = Object.keys(node);
+        const childrenVal = node._children;
         console.log(
-            `${indent}[${depth}] name="${node.name}" _gpu=${hasMesh ? "YES" : "no"}` +
-            ` material=${node.material ? node.material.constructor?.name ?? "object" : "none"}` +
-            ` skeleton=${node.skeleton ? "YES" : "no"}` +
-            ` _children=${node._children?.length ?? 0}`
+            `${indent}name="${node.name}" _gpu=${"_gpu" in node}` +
+            ` material=${"material" in node}` +
+            ` skeleton=${"skeleton" in node}` +
+            ` _children type=${Array.isArray(childrenVal) ? "Array("+childrenVal.length+")" : typeof childrenVal}`
         );
-        if (gpu) {
-            console.log(`${indent}    gpu.indexBuffer=`, gpu.indexBuffer ?? "(none)");
-            console.log(`${indent}    gpu.vertexBuffers=`, gpu.vertexBuffers ?? "(none)");
-            console.log(`${indent}    gpu.indexCount=`, gpu.indexCount ?? gpu.indicesCount ?? "(n/a)");
-            console.log(`${indent}    gpu keys:`, Object.keys(gpu));
+        console.log(`${indent}  ownKeys:`, ownKeys);
+        if ("_gpu" in node && node._gpu) {
+            const g = node._gpu;
+            console.log(`${indent}  gpu keys:`, Object.keys(g));
+            console.log(`${indent}  gpu.indexCount=`, g.indexCount ?? g.indicesCount ?? g.count ?? "(n/a)");
         }
-        if (node.material) {
-            console.log(`${indent}    material keys:`, Object.keys(node.material));
-            console.log(`${indent}    material._buildGroup=`, node.material._buildGroup ?? "(null)");
+        if ("material" in node && node.material) {
+            console.log(`${indent}  material._buildGroup=`, node.material._buildGroup ?? "(null)");
         }
-        if (node.skeleton) {
-            console.log(`${indent}    skeleton keys:`, Object.keys(node.skeleton));
-            console.log(`${indent}    skeleton.boneCount=`, node.skeleton.boneCount);
-        }
-        for (const child of node._children ?? []) {
+        for (const child of childrenVal ?? []) {
             inspectNode(child, depth + 1);
         }
     }
 
     console.group("[Fox] loadGltf result");
     console.log("foxAsset keys:", Object.keys(foxAsset));
-    console.log("foxAsset.entities.length:", foxAsset.entities?.length);
-    console.log("--- entity tree ---");
+    console.log("foxRoot ownKeys:", Object.keys(foxAsset.entities[0]));
+    console.log("foxRoot full props (for..in):");
+    const foxRootProps = {};
+    for (const k in foxAsset.entities[0]) foxRootProps[k] = typeof foxAsset.entities[0][k];
+    console.log(foxRootProps);
+    console.log("--- Fox entity tree ---");
     foxAsset.entities?.forEach(e => inspectNode(e));
     console.log("animationGroups:", foxAsset.animationGroups?.map((ag, i) =>
-        `[${i}] name="${ag.name}" stopped=${ag._stopped} isPlaying=${ag.isPlaying}`
+        `[${i}] name="${ag.name}" stopped=${ag._stopped}`
     ));
     console.groupEnd();
-    // ---- end Fox debug ----
 
     // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
     // addToScene auto-registers and plays all animation groups;
@@ -128,6 +128,12 @@ async function init() {
     }
 
     // T-Rex
+    console.group("[T-Rex] loadGltf result (for comparison)");
+    console.log("entities.length:", trexAsset.entities?.length);
+    console.log("--- T-Rex entity tree ---");
+    trexAsset.entities?.forEach(e => inspectNode(e));
+    console.groupEnd();
+
     const trexRoot = trexAsset.entities[0];
     trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     trexRoot.position.set(0, 0, -3);

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -72,6 +72,31 @@ async function init() {
     track2.material = trackMaterial;
     addToScene(scene, track2);
 
+    // ---- Fox debug ----
+    console.group("[Fox] loadGltf result");
+    console.log("foxAsset keys:", Object.keys(foxAsset));
+    console.log("foxAsset.entities.length:", foxAsset.entities?.length);
+    foxAsset.entities?.forEach((e, i) => {
+        const keys = Object.keys(e);
+        console.group(`  entity[${i}] name="${e.name ?? "(none)"}" constructor=${e.constructor?.name}`);
+        console.log("  keys:", keys);
+        console.log("  has _gpu:", "_gpu" in e);
+        console.log("  has material:", "material" in e);
+        console.log("  has skeleton:", "skeleton" in e);
+        console.log("  material:", e.material ?? null);
+        console.log("  skeleton:", e.skeleton ?? null);
+        console.log("  position:", e.position);
+        console.log("  scaling:", e.scaling);
+        console.log("  visibility:", e.visibility ?? "(n/a)");
+        console.log("  isEnabled:", typeof e.isEnabled === "function" ? e.isEnabled() : e.isEnabled ?? "(n/a)");
+        console.groupEnd();
+    });
+    console.log("animationGroups:", foxAsset.animationGroups?.map((ag, i) =>
+        `[${i}] name="${ag.name}" stopped=${ag._stopped} isPlaying=${ag.isPlaying}`
+    ));
+    console.groupEnd();
+    // ---- end Fox debug ----
+
     // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
     // addToScene auto-registers and plays all animation groups;
     // stop Survey and Walk so only Run plays (matches Babylon.js animationGroups[2].play(true))
@@ -80,9 +105,25 @@ async function init() {
     foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     foxRoot.position.set(0, 0, 0);
     addToScene(scene, foxAsset);
+
+    console.group("[Fox] after addToScene");
+    console.log("scene._meshes count:", scene._meshes?.length ?? scene.meshes?.length ?? "(unknown key)");
+    // Check all scene collections for Fox entities
+    for (const key of Object.keys(scene)) {
+        const val = scene[key];
+        if (Array.isArray(val) && val.length > 0 && val.some(x => x && typeof x === "object" && x.name?.startsWith("Fox"))) {
+            console.log(`  scene.${key} has Fox entries:`, val.filter(x => x?.name?.startsWith("Fox")).map(x => x.name));
+        }
+    }
+    console.groupEnd();
+
     if (foxAsset.animationGroups?.length >= 3) {
         stopAnimation(foxAsset.animationGroups[0]); // Survey
         stopAnimation(foxAsset.animationGroups[1]); // Walk
+        console.log("[Fox] stopped Survey and Walk; Run state:", {
+            stopped: foxAsset.animationGroups[2]._stopped,
+            isPlaying: foxAsset.animationGroups[2].isPlaying,
+        });
     }
 
     // T-Rex
@@ -116,6 +157,19 @@ async function init() {
     });
 
     await registerScene(scene);
+
+    // ---- post-register debug ----
+    console.group("[Fox] after registerScene");
+    console.log("scene._renderables count:", scene._renderables?.length ?? "(unknown)");
+    console.log("scene._deferredBuilders remaining:", scene._deferredBuilders?.length ?? 0);
+    const foxEntities = foxAsset.entities ?? [];
+    foxEntities.forEach((e, i) => {
+        console.log(`  fox entity[${i}] name="${e.name}" material._buildGroup:`,
+            e.material?._buildGroup ?? "(no material or _buildGroup)");
+    });
+    console.groupEnd();
+    // ---- end post-register debug ----
+
     await startEngine(engine);
 }
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -3,7 +3,6 @@ import {
     attachControl,
     createArcRotateCamera,
     createEngine,
-    createFreeCamera,
     createSceneContext,
     loadGltf,
     registerScene,
@@ -60,8 +59,10 @@ async function init() {
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 
-    // Use a simple free camera looking at the origin
-    scene.camera = createFreeCamera({ x: 0, y: 0, z: -5 }, { x: 0, y: 0, z: 0 });
+    // Triangle vertices: (0,0,0)-(1,1,0) range; orbit camera targeting (0.5, 0.5, 0)
+    const cam = createArcRotateCamera(Math.PI / 2, Math.PI / 3, 5, { x: 0.5, y: 0.5, z: 0 });
+    scene.camera = cam;
+    attachControl(cam, canvas, scene);
 
     // Test 1: Triangle (indexed - should work natively)
     const triangleUrl = "https://cx20.github.io/gltf-test/tutorialModels/Triangle/glTF/Triangle.gltf";
@@ -77,29 +78,43 @@ async function init() {
 
     URL.revokeObjectURL(triangleNoIdxUrl);
 
+    function logMeshNode(node, prefix = "") {
+        const hasGpu = "_gpu" in node;
+        const hasMat = "material" in node;
+        const idx = node._gpu?.indexCount;
+        const bg = node.material?._buildGroup;
+        console.log(
+            `${prefix}"${node.name}" _gpu=${hasGpu} material=${hasMat}` +
+            ` indexCount=${idx ?? "n/a"}` +
+            ` _buildGroup=${bg === null ? "null" : bg === undefined ? "undefined" : "SET"}`
+        );
+        for (const c of node.children ?? []) logMeshNode(c, prefix + "  ");
+    }
+
     if (triangleAsset) {
-        const root = triangleAsset.entities[0];
-        root.position.set(-1.5, 0, 0);
+        // No position offset - place at origin so camera (targeting 0.5,0.5,0) can see it
         addToScene(scene, triangleAsset);
-        console.log("[Triangle] added to scene. entities:", triangleAsset.entities.length);
-        // Log mesh
-        triangleAsset.entities[0].children?.forEach(c => {
-            console.log(`  child: "${c.name}" _gpu=${!!c._gpu} indexCount=${c._gpu?.indexCount}`);
-            c.children?.forEach(gc => console.log(`    grandchild: "${gc.name}" _gpu=${!!gc._gpu} indexCount=${gc._gpu?.indexCount}`));
-        });
+        console.group("[Triangle] after addToScene");
+        logMeshNode(triangleAsset.entities[0]);
+        console.groupEnd();
     }
     if (triangleNoIdxAsset) {
-        const root = triangleNoIdxAsset.entities[0];
-        root.position.set(1.5, 0, 0);
+        triangleNoIdxAsset.entities[0].position.set(2, 0, 0);
         addToScene(scene, triangleNoIdxAsset);
-        console.log("[TriangleNoIdx] added to scene. entities:", triangleNoIdxAsset.entities.length);
-        triangleNoIdxAsset.entities[0].children?.forEach(c => {
-            console.log(`  child: "${c.name}" _gpu=${!!c._gpu} indexCount=${c._gpu?.indexCount}`);
-            c.children?.forEach(gc => console.log(`    grandchild: "${gc.name}" _gpu=${!!gc._gpu} indexCount=${gc._gpu?.indexCount}`));
-        });
+        console.group("[TriangleNoIdx] after addToScene");
+        logMeshNode(triangleNoIdxAsset.entities[0]);
+        console.groupEnd();
     }
 
     await registerScene(scene);
+
+    console.log("scene._renderables after registerScene:", scene._renderables?.length);
+    if (triangleAsset) {
+        console.group("[Triangle] after registerScene");
+        logMeshNode(triangleAsset.entities[0]);
+        console.groupEnd();
+    }
+
     await startEngine(engine);
 }
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -54,6 +54,10 @@ async function init() {
     truckRoot.position.set(0, 0, 2);
     addToScene(scene, truckAsset);
 
+    console.group("[Truck] root (no skin - for comparison)");
+    dumpNode("truckRoot", truckAsset.entities[0]);
+    console.groupEnd();
+
     // Wheel tracks: two thin planes in the XZ plane (rotated from XY)
     // Matching Babylon.js: CreatePlane({width:100, height:0.1}), rotated PI/2 around X
     // z=1.6 (right track), z=2.35 (left track), centered behind the truck at x=-49.5
@@ -73,44 +77,36 @@ async function init() {
     addToScene(scene, track2);
 
     // ---- Fox debug ----
-    function inspectNode(node, depth = 0) {
-        const indent = "  ".repeat(depth);
-        const allKeys = [];
-        for (const k in node) allKeys.push(k); // includes non-own enumerable
+    function dumpNode(label, node) {
         const ownKeys = Object.keys(node);
-        const childrenVal = node._children;
-        console.log(
-            `${indent}name="${node.name}" _gpu=${"_gpu" in node}` +
-            ` material=${"material" in node}` +
-            ` skeleton=${"skeleton" in node}` +
-            ` _children type=${Array.isArray(childrenVal) ? "Array("+childrenVal.length+")" : typeof childrenVal}`
-        );
-        console.log(`${indent}  ownKeys:`, ownKeys);
-        if ("_gpu" in node && node._gpu) {
-            const g = node._gpu;
-            console.log(`${indent}  gpu keys:`, Object.keys(g));
-            console.log(`${indent}  gpu.indexCount=`, g.indexCount ?? g.indicesCount ?? g.count ?? "(n/a)");
-        }
-        if ("material" in node && node.material) {
-            console.log(`${indent}  material._buildGroup=`, node.material._buildGroup ?? "(null)");
-        }
-        for (const child of childrenVal ?? []) {
-            inspectNode(child, depth + 1);
+        const protoKeys = Object.getOwnPropertyNames(Object.getPrototypeOf(node) ?? {});
+        console.log(`${label} ownKeys: ${ownKeys.join(", ")}`);
+        console.log(`${label} protoKeys: ${protoKeys.join(", ")}`);
+        // Check every possible "children" property name
+        for (const k of [...ownKeys, ...protoKeys]) {
+            const v = node[k];
+            if (Array.isArray(v) && v.length > 0 && v[0] && typeof v[0] === "object") {
+                console.log(`  ${label}.${k} = Array(${v.length}) of objects [first name="${v[0].name}"]`);
+            }
         }
     }
 
     console.group("[Fox] loadGltf result");
-    console.log("foxAsset keys:", Object.keys(foxAsset));
-    console.log("foxRoot ownKeys:", Object.keys(foxAsset.entities[0]));
-    console.log("foxRoot full props (for..in):");
-    const foxRootProps = {};
-    for (const k in foxAsset.entities[0]) foxRootProps[k] = typeof foxAsset.entities[0][k];
-    console.log(foxRootProps);
-    console.log("--- Fox entity tree ---");
-    foxAsset.entities?.forEach(e => inspectNode(e));
+    dumpNode("foxRoot", foxAsset.entities[0]);
     console.log("animationGroups:", foxAsset.animationGroups?.map((ag, i) =>
-        `[${i}] name="${ag.name}" stopped=${ag._stopped}`
+        `[${i}] name="${ag.name ?? i}" stopped=${ag._stopped}`
     ));
+    // Inspect animation group internals for mesh references
+    const ag = foxAsset.animationGroups?.[0];
+    if (ag) {
+        console.log("animationGroup[0] keys:", Object.keys(ag).join(", "));
+        for (const k of Object.keys(ag)) {
+            const v = ag[k];
+            if (v && typeof v === "object" && !Array.isArray(v)) {
+                console.log(`  ag.${k} keys:`, Object.keys(v).join(", "));
+            }
+        }
+    }
     console.groupEnd();
 
     // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
@@ -166,11 +162,16 @@ async function init() {
     await registerScene(scene);
 
     // ---- post-register debug ----
-    console.group("[Fox] after registerScene");
-    console.log("scene._renderables count:", scene._renderables?.length ?? "(unknown)");
-    console.log("scene._deferredBuilders remaining:", scene._deferredBuilders?.length ?? 0);
-    console.log("--- Fox entity tree after registerScene ---");
-    foxAsset.entities?.forEach(e => inspectNode(e));
+    console.group("[Scene] after registerScene");
+    console.log("scene._renderables count:", scene._renderables?.length);
+    // Dump all scene keys and array-type properties
+    for (const k of Object.keys(scene)) {
+        const v = scene[k];
+        if (Array.isArray(v)) {
+            const names = v.map(x => x?.name ?? x?.constructor?.name ?? typeof x).join(", ");
+            console.log(`  scene.${k}[${v.length}]: ${names.slice(0, 120)}`);
+        }
+    }
     console.groupEnd();
     // ---- end post-register debug ----
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -43,6 +43,10 @@ async function patchGltfAddIndices(gltfUrl) {
 
     for (const mat of json.materials ?? []) mat.doubleSided = true;
 
+    // TEST: Remove skinning to confirm static mesh renders correctly
+    for (const node of json.nodes ?? []) { if (node.skin != null) delete node.skin; }
+    if (json.skins) json.skins.length = 0;
+
     const toBase64 = (typedArray) => {
         const bytes = new Uint8Array(typedArray.buffer);
         let binary = "";
@@ -133,7 +137,9 @@ async function init() {
 
     const foxMesh = foxAsset.entities[0]?.children?.[1]?.children?.[0];
     console.log("[Fox] mesh indexCount:", foxMesh?._gpu?.indexCount,
-        "hasNormal:", !!(foxMesh?._gpu?.normalBuffer), "material:", !!foxMesh?.material);
+        "hasNormal:", !!(foxMesh?._gpu?.normalBuffer),
+        "hasSkeleton:", !!(foxMesh?._gpu?.skeleton ?? foxMesh?.skeleton),
+        "material:", !!foxMesh?.material);
 
     const truckRoot = truckAsset.entities[0];
     truckRoot.scaling.set(-0.4, 0.4, 0.4);

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -39,12 +39,10 @@ async function patchGltfAddIndices(gltfUrl) {
     const prim = json.meshes[0].primitives[0];
     if (prim.indices != null) return gltfUrl; // already indexed, no patch needed
 
-    // Make existing buffer URIs absolute so they resolve from the Blob URL
-    for (const buf of json.buffers ?? []) {
-        if (buf.uri && !buf.uri.startsWith("data:") && !buf.uri.startsWith("http")) {
-            buf.uri = baseUrl + buf.uri;
-        }
-    }
+    // Make existing buffer and image URIs absolute so they resolve from the Blob URL
+    const makeAbsolute = uri => (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
+    for (const buf of json.buffers ?? []) { if (buf.uri) buf.uri = makeAbsolute(buf.uri); }
+    for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
 
     const vertexCount = json.accessors[prim.attributes.POSITION].count;
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -54,8 +54,8 @@ async function init() {
     truckRoot.position.set(0, 0, 2);
     addToScene(scene, truckAsset);
 
-    console.group("[Truck] root (no skin - for comparison)");
-    dumpNode("truckRoot", truckAsset.entities[0]);
+    console.group("[Truck] entity tree (no skin - for comparison)");
+    truckAsset.entities?.forEach(e => inspectTree(e));
     console.groupEnd();
 
     // Wheel tracks: two thin planes in the XZ plane (rotated from XY)
@@ -77,36 +77,32 @@ async function init() {
     addToScene(scene, track2);
 
     // ---- Fox debug ----
-    function dumpNode(label, node) {
-        const ownKeys = Object.keys(node);
-        const protoKeys = Object.getOwnPropertyNames(Object.getPrototypeOf(node) ?? {});
-        console.log(`${label} ownKeys: ${ownKeys.join(", ")}`);
-        console.log(`${label} protoKeys: ${protoKeys.join(", ")}`);
-        // Check every possible "children" property name
-        for (const k of [...ownKeys, ...protoKeys]) {
-            const v = node[k];
-            if (Array.isArray(v) && v.length > 0 && v[0] && typeof v[0] === "object") {
-                console.log(`  ${label}.${k} = Array(${v.length}) of objects [first name="${v[0].name}"]`);
-            }
+    function inspectTree(node, depth = 0) {
+        const indent = "  ".repeat(depth);
+        const hasGpu = "_gpu" in node;
+        const hasMat = "material" in node;
+        const children = node.children ?? [];
+        let line = `${indent}[${depth}] "${node.name}" _gpu=${hasGpu} material=${hasMat} children=${children.length}`;
+        if (hasGpu && node._gpu) {
+            const g = node._gpu;
+            const gkeys = Object.keys(g);
+            const idxCount = g.indexCount ?? g.indicesCount ?? g.indexBuffer?.size ?? "(n/a)";
+            line += ` | gpu keys:[${gkeys.join(",")}] indexCount=${idxCount}`;
         }
+        if (hasMat && node.material) {
+            const bg = node.material._buildGroup;
+            line += ` | _buildGroup=${bg === null ? "null" : bg === undefined ? "undefined" : "SET"}`;
+            line += ` | mat keys:[${Object.keys(node.material).join(",")}]`;
+        }
+        if ("skeleton" in node && node.skeleton) {
+            line += ` | skeleton boneCount=${node.skeleton.boneCount}`;
+        }
+        console.log(line);
+        for (const child of children) inspectTree(child, depth + 1);
     }
 
-    console.group("[Fox] loadGltf result");
-    dumpNode("foxRoot", foxAsset.entities[0]);
-    console.log("animationGroups:", foxAsset.animationGroups?.map((ag, i) =>
-        `[${i}] name="${ag.name ?? i}" stopped=${ag._stopped}`
-    ));
-    // Inspect animation group internals for mesh references
-    const ag = foxAsset.animationGroups?.[0];
-    if (ag) {
-        console.log("animationGroup[0] keys:", Object.keys(ag).join(", "));
-        for (const k of Object.keys(ag)) {
-            const v = ag[k];
-            if (v && typeof v === "object" && !Array.isArray(v)) {
-                console.log(`  ag.${k} keys:`, Object.keys(v).join(", "));
-            }
-        }
-    }
+    console.group("[Fox] entity tree");
+    foxAsset.entities?.forEach(e => inspectTree(e));
     console.groupEnd();
 
     // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
@@ -124,10 +120,8 @@ async function init() {
     }
 
     // T-Rex
-    console.group("[T-Rex] loadGltf result (for comparison)");
-    console.log("entities.length:", trexAsset.entities?.length);
-    console.log("--- T-Rex entity tree ---");
-    trexAsset.entities?.forEach(e => inspectNode(e));
+    console.group("[T-Rex] entity tree (for comparison)");
+    trexAsset.entities?.forEach(e => inspectTree(e));
     console.groupEnd();
 
     const trexRoot = trexAsset.entities[0];
@@ -162,16 +156,8 @@ async function init() {
     await registerScene(scene);
 
     // ---- post-register debug ----
-    console.group("[Scene] after registerScene");
-    console.log("scene._renderables count:", scene._renderables?.length);
-    // Dump all scene keys and array-type properties
-    for (const k of Object.keys(scene)) {
-        const v = scene[k];
-        if (Array.isArray(v)) {
-            const names = v.map(x => x?.name ?? x?.constructor?.name ?? typeof x).join(", ");
-            console.log(`  scene.${k}[${v.length}]: ${names.slice(0, 120)}`);
-        }
-    }
+    console.group("[Fox] entity tree after registerScene");
+    foxAsset.entities?.forEach(e => inspectTree(e));
     console.groupEnd();
     // ---- end post-register debug ----
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -2,53 +2,60 @@ import {
     addToScene,
     attachControl,
     createArcRotateCamera,
+    createDirectionalLight,
     createEngine,
+    createHemisphericLight,
+    createPlane,
     createSceneContext,
+    createStandardMaterial,
+    loadEnvironment,
     loadGltf,
+    loadSkybox,
+    onBeforeRender,
     registerScene,
     startEngine,
+    stopAnimation,
 } from "https://esm.sh/@babylonjs/lite@1.0.1";
 
-// Patch non-indexed GLtF to add sequential indices as a data URI buffer
+const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
+const BRDF_URL = "https://raw.githubusercontent.com/BabylonJS/Babylon-Lite/master/lab/public/brdf-lut.png";
+
+// Match Babylon.js: camera.setPosition(new BABYLON.Vector3(0, 5, 15))
+const CAM_RADIUS = Math.sqrt(250);
+const CAM_BETA = Math.acos(5 / CAM_RADIUS);
+
+// Quaternion for 90 degree rotation around Y axis
+const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
+
+// Fox.gltf has no `indices` field (non-indexed geometry).
+// Babylon.js Lite only supports drawIndexed(), so we patch the GLTF at runtime
+// to add sequential indices [0, 1, 2, ..., N-1] and return a Blob URL.
 async function patchGltfAddIndices(gltfUrl) {
     const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
     const json = await fetch(gltfUrl).then(r => r.json());
     const prim = json.meshes[0].primitives[0];
+    if (prim.indices != null) return gltfUrl;
 
-    console.log(`[patch] ${gltfUrl}`);
-    console.log(`  indices before: ${prim.indices ?? "MISSING (non-indexed)"}`);
-    console.log(`  mode: ${prim.mode ?? 4} (4=TRIANGLES)`);
-
-    if (prim.indices != null) {
-        const acc = json.accessors[prim.indices];
-        console.log(`  already indexed: count=${acc.count} componentType=${acc.componentType}`);
-        return gltfUrl; // already indexed, no patch needed
-    }
-
-    const makeAbsolute = uri => (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
+    const makeAbsolute = uri =>
+        (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
     for (const buf of json.buffers ?? []) { if (buf.uri) buf.uri = makeAbsolute(buf.uri); }
     for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
 
     const vertexCount = json.accessors[prim.attributes.POSITION].count;
-    console.log(`  vertexCount: ${vertexCount} → adding indices [0..${vertexCount-1}]`);
-
     const indices = new Uint16Array(vertexCount);
     for (let i = 0; i < vertexCount; i++) indices[i] = i;
 
     const bytes = new Uint8Array(indices.buffer);
     let binary = "";
     for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-    const dataUri = "data:application/octet-stream;base64," + btoa(binary);
 
     const bufIdx = json.buffers.length;
-    json.buffers.push({ uri: dataUri, byteLength: indices.byteLength });
+    json.buffers.push({ uri: "data:application/octet-stream;base64," + btoa(binary), byteLength: indices.byteLength });
     const bvIdx = json.bufferViews.length;
     json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
     const accIdx = json.accessors.length;
     json.accessors.push({ bufferView: bvIdx, componentType: 5123, count: vertexCount, type: "SCALAR" });
-
     prim.indices = accIdx;
-    console.log(`  patch applied: new accessor[${accIdx}] indexCount=${vertexCount}`);
 
     const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
     return URL.createObjectURL(blob);
@@ -59,65 +66,84 @@ async function init() {
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 
-    // Triangle vertices: (0,0,0)-(1,1,0) range; orbit camera targeting (0.5, 0.5, 0)
-    const cam = createArcRotateCamera(Math.PI / 2, Math.PI / 3, 5, { x: 0.5, y: 0.5, z: 0 });
+    const cam = createArcRotateCamera(Math.PI / 2, CAM_BETA, CAM_RADIUS, { x: 0, y: 0, z: 0 });
     scene.camera = cam;
     attachControl(cam, canvas, scene);
 
-    // Test 1: Triangle (indexed - should work natively)
-    const triangleUrl = "https://cx20.github.io/gltf-test/tutorialModels/Triangle/glTF/Triangle.gltf";
-    // Test 2: TriangleWithoutIndices (non-indexed - requires patch)
-    const triangleNoIdxUrl = await patchGltfAddIndices(
-        "https://cx20.github.io/gltf-test/tutorialModels/TriangleWithoutIndices/glTF/TriangleWithoutIndices.gltf"
+    const foxGltfUrl = await patchGltfAddIndices(
+        "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"
     );
 
-    console.log("[test] loading Triangle (indexed)...");
-    const triangleAsset = await loadGltf(engine, triangleUrl).catch(e => { console.error("[Triangle] load error:", e); return null; });
-    console.log("[test] loading TriangleWithoutIndices (patched)...");
-    const triangleNoIdxAsset = await loadGltf(engine, triangleNoIdxUrl).catch(e => { console.error("[TriangleNoIdx] load error:", e); return null; });
+    const [truckAsset, foxAsset, trexAsset] = await Promise.all([
+        loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf"),
+        loadGltf(engine, foxGltfUrl),
+        loadGltf(engine, "https://raw.githubusercontent.com/BabylonJS/Exporters/d66db9a7042fef66acb62e1b8770739463b0b567/Maya/Samples/glTF%202.0/T-Rex/trex.gltf"),
+    ]);
 
-    URL.revokeObjectURL(triangleNoIdxUrl);
+    URL.revokeObjectURL(foxGltfUrl);
 
-    function logMeshNode(node, prefix = "") {
-        const hasGpu = "_gpu" in node;
-        const hasMat = "material" in node;
-        const idx = node._gpu?.indexCount;
-        const bg = node.material?._buildGroup;
-        console.log(
-            `${prefix}"${node.name}" _gpu=${hasGpu} material=${hasMat}` +
-            ` indexCount=${idx ?? "n/a"}` +
-            ` _buildGroup=${bg === null ? "null" : bg === undefined ? "undefined" : "SET"}`
-        );
-        for (const c of node.children ?? []) logMeshNode(c, prefix + "  ");
+    // Quick Fox sanity check
+    const foxMesh = foxAsset.entities[0]?.children?.[1]?.children?.[0];
+    console.log("[Fox] mesh indexCount:", foxMesh?._gpu?.indexCount, "material:", !!foxMesh?.material);
+
+    const truckRoot = truckAsset.entities[0];
+    truckRoot.scaling.set(-0.4, 0.4, 0.4);
+    truckRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
+    truckRoot.position.set(0, 0, 2);
+    addToScene(scene, truckAsset);
+
+    const trackMaterial = createStandardMaterial();
+    trackMaterial.diffuseColor = [0.3, 0.25, 0.2];
+
+    const track1 = createPlane(engine, { width: 100, height: 0.1 });
+    track1.rotation.x = Math.PI / 2;
+    track1.position.set(-49.5, 0, 1.6);
+    track1.material = trackMaterial;
+    addToScene(scene, track1);
+
+    const track2 = createPlane(engine, { width: 100, height: 0.1 });
+    track2.rotation.x = Math.PI / 2;
+    track2.position.set(-49.5, 0, 2.35);
+    track2.material = trackMaterial;
+    addToScene(scene, track2);
+
+    const foxRoot = foxAsset.entities[0];
+    foxRoot.scaling.set(-0.05, 0.05, 0.05);
+    foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
+    foxRoot.position.set(0, 0, 0);
+    addToScene(scene, foxAsset);
+    if (foxAsset.animationGroups?.length >= 3) {
+        stopAnimation(foxAsset.animationGroups[0]); // Survey
+        stopAnimation(foxAsset.animationGroups[1]); // Walk
     }
 
-    if (triangleAsset) {
-        // No position offset - place at origin so camera (targeting 0.5,0.5,0) can see it
-        addToScene(scene, triangleAsset);
-        console.group("[Triangle] after addToScene");
-        logMeshNode(triangleAsset.entities[0]);
-        console.groupEnd();
-    }
-    if (triangleNoIdxAsset) {
-        triangleNoIdxAsset.entities[0].position.set(2, 0, 0);
-        addToScene(scene, triangleNoIdxAsset);
-        console.group("[TriangleNoIdx] after addToScene");
-        logMeshNode(triangleNoIdxAsset.entities[0]);
-        console.groupEnd();
-    }
+    const trexRoot = trexAsset.entities[0];
+    trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
+    trexRoot.position.set(0, 0, -3);
+    addToScene(scene, trexAsset);
+
+    const light0 = createHemisphericLight([1, 1, 0]);
+    addToScene(scene, light0);
+    const light1 = createDirectionalLight([0.0, -1.0, 0.5]);
+    addToScene(scene, light1);
+    const light2 = createDirectionalLight([-0.5, -0.5, -0.5]);
+    addToScene(scene, light2);
+
+    await loadEnvironment(scene, ENV_URL, {
+        skipSkybox: true,
+        skipGround: true,
+        brdfUrl: BRDF_URL,
+    });
+
+    await loadSkybox(scene, "https://playground.babylonjs.com/textures/skybox", ".jpg");
+
+    onBeforeRender(scene, () => { cam.alpha -= 0.005; });
 
     await registerScene(scene);
 
-    console.log("scene._renderables after registerScene:", scene._renderables?.length);
-    if (triangleAsset) {
-        console.group("[Triangle] after registerScene");
-        logMeshNode(triangleAsset.entities[0]);
-        console.groupEnd();
-    }
+    console.log("[scene] renderables:", scene._renderables?.length);
 
     await startEngine(engine);
 }
 
-init().catch((error) => {
-    console.error(error);
-});
+init().catch((error) => { console.error(error); });

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -2,55 +2,40 @@ import {
     addToScene,
     attachControl,
     createArcRotateCamera,
-    createDirectionalLight,
     createEngine,
-    createHemisphericLight,
-    createPlane,
+    createFreeCamera,
     createSceneContext,
-    createStandardMaterial,
-    loadEnvironment,
     loadGltf,
-    loadSkybox,
-    onBeforeRender,
     registerScene,
     startEngine,
-    stopAnimation,
 } from "https://esm.sh/@babylonjs/lite@1.0.1";
 
-const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
-const BRDF_URL = "https://raw.githubusercontent.com/BabylonJS/Babylon-Lite/master/lab/public/brdf-lut.png";
-
-// Match Babylon.js: camera.setPosition(new BABYLON.Vector3(0, 5, 15))
-// ArcRotateCamera formula: x=r*cos(a)*sin(b), y=r*cos(b), z=r*sin(a)*sin(b)
-// → alpha=PI/2, beta=acos(5/sqrt(250)), radius=sqrt(250)
-const CAM_RADIUS = Math.sqrt(250);
-const CAM_BETA = Math.acos(5 / CAM_RADIUS);
-
-// Quaternion for 90 degree rotation around Y axis
-const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
-
-// Fox.gltf has no `indices` field (non-indexed geometry).
-// Babylon.js Lite only supports drawIndexed(), so we patch the GLTF at runtime
-// to add sequential indices [0, 1, 2, ..., N-1] and return a Blob URL.
+// Patch non-indexed GLtF to add sequential indices as a data URI buffer
 async function patchGltfAddIndices(gltfUrl) {
     const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
     const json = await fetch(gltfUrl).then(r => r.json());
-
     const prim = json.meshes[0].primitives[0];
-    if (prim.indices != null) return gltfUrl; // already indexed, no patch needed
 
-    // Make existing buffer and image URIs absolute so they resolve from the Blob URL
+    console.log(`[patch] ${gltfUrl}`);
+    console.log(`  indices before: ${prim.indices ?? "MISSING (non-indexed)"}`);
+    console.log(`  mode: ${prim.mode ?? 4} (4=TRIANGLES)`);
+
+    if (prim.indices != null) {
+        const acc = json.accessors[prim.indices];
+        console.log(`  already indexed: count=${acc.count} componentType=${acc.componentType}`);
+        return gltfUrl; // already indexed, no patch needed
+    }
+
     const makeAbsolute = uri => (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
     for (const buf of json.buffers ?? []) { if (buf.uri) buf.uri = makeAbsolute(buf.uri); }
     for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
 
     const vertexCount = json.accessors[prim.attributes.POSITION].count;
+    console.log(`  vertexCount: ${vertexCount} → adding indices [0..${vertexCount-1}]`);
 
-    // Build sequential UINT16 index buffer [0, 1, 2, ..., vertexCount-1]
     const indices = new Uint16Array(vertexCount);
     for (let i = 0; i < vertexCount; i++) indices[i] = i;
 
-    // Encode as base64 data URI
     const bytes = new Uint8Array(indices.buffer);
     let binary = "";
     for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
@@ -58,14 +43,13 @@ async function patchGltfAddIndices(gltfUrl) {
 
     const bufIdx = json.buffers.length;
     json.buffers.push({ uri: dataUri, byteLength: indices.byteLength });
-
     const bvIdx = json.bufferViews.length;
     json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
-
     const accIdx = json.accessors.length;
-    json.accessors.push({ bufferView: bvIdx, componentType: 5123 /* UNSIGNED_SHORT */, count: vertexCount, type: "SCALAR" });
+    json.accessors.push({ bufferView: bvIdx, componentType: 5123, count: vertexCount, type: "SCALAR" });
 
     prim.indices = accIdx;
+    console.log(`  patch applied: new accessor[${accIdx}] indexCount=${vertexCount}`);
 
     const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
     return URL.createObjectURL(blob);
@@ -76,92 +60,44 @@ async function init() {
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 
-    const cam = createArcRotateCamera(Math.PI / 2, CAM_BETA, CAM_RADIUS, { x: 0, y: 0, z: 0 });
-    scene.camera = cam;
-    attachControl(cam, canvas, scene);
+    // Use a simple free camera looking at the origin
+    scene.camera = createFreeCamera({ x: 0, y: 0, z: -5 }, { x: 0, y: 0, z: 0 });
 
-    const foxUrl = await patchGltfAddIndices(
-        "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"
+    // Test 1: Triangle (indexed - should work natively)
+    const triangleUrl = "https://cx20.github.io/gltf-test/tutorialModels/Triangle/glTF/Triangle.gltf";
+    // Test 2: TriangleWithoutIndices (non-indexed - requires patch)
+    const triangleNoIdxUrl = await patchGltfAddIndices(
+        "https://cx20.github.io/gltf-test/tutorialModels/TriangleWithoutIndices/glTF/TriangleWithoutIndices.gltf"
     );
 
-    const [truckAsset, foxAsset, trexAsset] = await Promise.all([
-        loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf"),
-        loadGltf(engine, foxUrl),
-        loadGltf(engine, "https://raw.githubusercontent.com/BabylonJS/Exporters/d66db9a7042fef66acb62e1b8770739463b0b567/Maya/Samples/glTF%202.0/T-Rex/trex.gltf"),
-    ]);
+    console.log("[test] loading Triangle (indexed)...");
+    const triangleAsset = await loadGltf(engine, triangleUrl).catch(e => { console.error("[Triangle] load error:", e); return null; });
+    console.log("[test] loading TriangleWithoutIndices (patched)...");
+    const triangleNoIdxAsset = await loadGltf(engine, triangleNoIdxUrl).catch(e => { console.error("[TriangleNoIdx] load error:", e); return null; });
 
-    URL.revokeObjectURL(foxUrl);
+    URL.revokeObjectURL(triangleNoIdxUrl);
 
-    // AssetContainer root is entities[0]: a TransformNode with scaling (-1,1,1)
-    // Preserve the -1 x-scale when applying model scale: set(-scale, scale, scale)
-
-    // CesiumMilkTruck
-    const truckRoot = truckAsset.entities[0];
-    truckRoot.scaling.set(-0.4, 0.4, 0.4);
-    truckRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
-    truckRoot.position.set(0, 0, 2);
-    addToScene(scene, truckAsset);
-
-    // Wheel tracks: two thin planes in the XZ plane (rotated from XY)
-    // Matching Babylon.js: CreatePlane({width:100, height:0.1}), rotated PI/2 around X
-    // z=1.6 (right track), z=2.35 (left track), centered behind the truck at x=-49.5
-    const trackMaterial = createStandardMaterial();
-    trackMaterial.diffuseColor = [0.3, 0.25, 0.2];
-
-    const track1 = createPlane(engine, { width: 100, height: 0.1 });
-    track1.rotation.x = Math.PI / 2;
-    track1.position.set(-49.5, 0, 1.6);
-    track1.material = trackMaterial;
-    addToScene(scene, track1);
-
-    const track2 = createPlane(engine, { width: 100, height: 0.1 });
-    track2.rotation.x = Math.PI / 2;
-    track2.position.set(-49.5, 0, 2.35);
-    track2.material = trackMaterial;
-    addToScene(scene, track2);
-
-    // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
-    // addToScene auto-registers and plays all animation groups;
-    // stop Survey and Walk so only Run plays (matches Babylon.js animationGroups[2].play(true))
-    const foxRoot = foxAsset.entities[0];
-    foxRoot.scaling.set(-0.05, 0.05, 0.05);
-    foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
-    foxRoot.position.set(0, 0, 0);
-    addToScene(scene, foxAsset);
-    if (foxAsset.animationGroups?.length >= 3) {
-        stopAnimation(foxAsset.animationGroups[0]); // Survey
-        stopAnimation(foxAsset.animationGroups[1]); // Walk
+    if (triangleAsset) {
+        const root = triangleAsset.entities[0];
+        root.position.set(-1.5, 0, 0);
+        addToScene(scene, triangleAsset);
+        console.log("[Triangle] added to scene. entities:", triangleAsset.entities.length);
+        // Log mesh
+        triangleAsset.entities[0].children?.forEach(c => {
+            console.log(`  child: "${c.name}" _gpu=${!!c._gpu} indexCount=${c._gpu?.indexCount}`);
+            c.children?.forEach(gc => console.log(`    grandchild: "${gc.name}" _gpu=${!!gc._gpu} indexCount=${gc._gpu?.indexCount}`));
+        });
     }
-
-    // T-Rex
-    const trexRoot = trexAsset.entities[0];
-    trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
-    trexRoot.position.set(0, 0, -3);
-    addToScene(scene, trexAsset);
-
-    const light0 = createHemisphericLight([1, 1, 0]);
-    addToScene(scene, light0);
-
-    const light1 = createDirectionalLight([0.0, -1.0, 0.5]);
-    addToScene(scene, light1);
-
-    const light2 = createDirectionalLight([-0.5, -0.5, -0.5]);
-    addToScene(scene, light2);
-
-    // IBL environment for PBR materials (Fox, T-Rex use PBR from GLtF)
-    // Skybox is handled separately by loadSkybox below
-    await loadEnvironment(scene, ENV_URL, {
-        skipSkybox: true,
-        skipGround: true,
-        brdfUrl: BRDF_URL,
-    });
-
-    // Skybox: playground URL uses _px/_nx naming convention that loadSkybox expects
-    await loadSkybox(scene, "https://playground.babylonjs.com/textures/skybox", ".jpg");
-
-    onBeforeRender(scene, () => {
-        cam.alpha -= 0.005;
-    });
+    if (triangleNoIdxAsset) {
+        const root = triangleNoIdxAsset.entities[0];
+        root.position.set(1.5, 0, 0);
+        addToScene(scene, triangleNoIdxAsset);
+        console.log("[TriangleNoIdx] added to scene. entities:", triangleNoIdxAsset.entities.length);
+        triangleNoIdxAsset.entities[0].children?.forEach(c => {
+            console.log(`  child: "${c.name}" _gpu=${!!c._gpu} indexCount=${c._gpu?.indexCount}`);
+            c.children?.forEach(gc => console.log(`    grandchild: "${gc.name}" _gpu=${!!gc._gpu} indexCount=${gc._gpu?.indexCount}`));
+        });
+    }
 
     await registerScene(scene);
     await startEngine(engine);

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -27,11 +27,14 @@ const CAM_BETA = Math.acos(5 / CAM_RADIUS);
 // Quaternion for 90 degree rotation around Y axis
 const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
 
-// Fox.gltf has two issues for Babylon.js Lite:
-// 1. No `indices` field (non-indexed geometry) — Lite always calls drawIndexed()
-// 2. No NORMAL attribute — PBR shader needs normals for lighting
-// We also set doubleSided=true to fix backface culling with negative-X scaling.
-async function patchGltfAddIndices(gltfUrl) {
+// Fox.gltf has no `indices` field (non-indexed geometry).
+// Babylon.js Lite only supports drawIndexed(), so we patch at runtime:
+//   - add sequential indices [0..N-1]
+//   - synthesize flat normals from POSITION data (NORMAL attribute is absent)
+//   - set doubleSided=true to prevent backface culling with negative-X scale
+// NOTE: Despite these patches, Fox is not rendered correctly in Babylon.js Lite v1.0.1.
+//       Non-indexed glTF geometry is a known limitation of this engine version.
+async function patchGltfForLite(gltfUrl) {
     const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
     const json = await fetch(gltfUrl).then(r => r.json());
     const prim = json.meshes[0].primitives[0];
@@ -42,10 +45,6 @@ async function patchGltfAddIndices(gltfUrl) {
     for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
 
     for (const mat of json.materials ?? []) mat.doubleSided = true;
-
-    // TEST: Remove skinning to confirm static mesh renders correctly
-    for (const node of json.nodes ?? []) { if (node.skin != null) delete node.skin; }
-    if (json.skins) json.skins.length = 0;
 
     const toBase64 = (typedArray) => {
         const bytes = new Uint8Array(typedArray.buffer);
@@ -71,7 +70,6 @@ async function patchGltfAddIndices(gltfUrl) {
     }
 
     if (prim.attributes.NORMAL == null) {
-        // Fetch position data to compute proper flat normals
         const posAcc = json.accessors[prim.attributes.POSITION];
         const posBv = json.bufferViews[posAcc.bufferView];
         const binData = await fetch(json.buffers[posBv.buffer].uri).then(r => r.arrayBuffer());
@@ -107,7 +105,6 @@ async function patchGltfAddIndices(gltfUrl) {
         const normAccIdx = json.accessors.length;
         json.accessors.push({ bufferView: normBvIdx, componentType: 5126, count: vertexCount, type: "VEC3" });
         prim.attributes.NORMAL = normAccIdx;
-        console.log("[Fox patch] Added synthetic flat normals, vertexCount:", vertexCount);
     }
 
     const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
@@ -123,7 +120,7 @@ async function init() {
     scene.camera = cam;
     attachControl(cam, canvas, scene);
 
-    const foxGltfUrl = await patchGltfAddIndices(
+    const foxGltfUrl = await patchGltfForLite(
         "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"
     );
 
@@ -134,12 +131,6 @@ async function init() {
     ]);
 
     URL.revokeObjectURL(foxGltfUrl);
-
-    const foxMesh = foxAsset.entities[0]?.children?.[1]?.children?.[0];
-    console.log("[Fox] mesh indexCount:", foxMesh?._gpu?.indexCount,
-        "hasNormal:", !!(foxMesh?._gpu?.normalBuffer),
-        "hasSkeleton:", !!(foxMesh?._gpu?.skeleton ?? foxMesh?.skeleton),
-        "material:", !!foxMesh?.material);
 
     const truckRoot = truckAsset.entities[0];
     truckRoot.scaling.set(-0.4, 0.4, 0.4);
@@ -170,7 +161,7 @@ async function init() {
     if (foxAsset.animationGroups?.length >= 3) {
         stopAnimation(foxAsset.animationGroups[0]); // Survey
         stopAnimation(foxAsset.animationGroups[1]); // Walk
-        // animationGroups[2] = Run — keep playing
+        // animationGroups[2] = Run
     }
 
     const trexRoot = trexAsset.entities[0];
@@ -196,9 +187,6 @@ async function init() {
     onBeforeRender(scene, () => { cam.alpha -= 0.005; });
 
     await registerScene(scene);
-
-    console.log("[scene] renderables:", scene._renderables?.length);
-
     await startEngine(engine);
 }
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -112,10 +112,21 @@ async function init() {
     foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     foxRoot.position.set(0, 0, 0);
     addToScene(scene, foxAsset);
-    if (foxAsset.animationGroups?.length >= 3) {
-        stopAnimation(foxAsset.animationGroups[0]); // Survey
-        stopAnimation(foxAsset.animationGroups[1]); // Walk
-    }
+    // Stop ALL animations to test bind pose visibility
+    for (const ag of foxAsset.animationGroups ?? []) stopAnimation(ag);
+    console.log("[Fox] all animations stopped. animationGroups:",
+        foxAsset.animationGroups?.map(ag => `${ag.name} stopped=${ag._stopped}`));
+
+    // Log Fox mesh world matrix after first render to confirm world position
+    let foxFrameCount = 0;
+    const foxMeshNode = foxAsset.entities[0]?.children?.[1]?.children?.[0];
+    onBeforeRender(scene, () => {
+        if (foxFrameCount++ === 2 && foxMeshNode) {
+            const wm = foxMeshNode.worldMatrix;
+            console.log("[Fox] worldMatrix after 2 frames:", wm ? Array.from(wm).map(v => v.toFixed(3)).join(",") : "(none)");
+            console.log("[Fox] foxRoot.position:", foxRoot.position, "scaling:", foxRoot.scaling);
+        }
+    });
 
     const trexRoot = trexAsset.entities[0];
     trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -27,35 +27,84 @@ const CAM_BETA = Math.acos(5 / CAM_RADIUS);
 // Quaternion for 90 degree rotation around Y axis
 const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
 
-// Fox.gltf has no `indices` field (non-indexed geometry).
-// Babylon.js Lite only supports drawIndexed(), so we patch the GLTF at runtime
-// to add sequential indices [0, 1, 2, ..., N-1] and return a Blob URL.
+// Fox.gltf has two issues for Babylon.js Lite:
+// 1. No `indices` field (non-indexed geometry) — Lite always calls drawIndexed()
+// 2. No NORMAL attribute — PBR shader needs normals for lighting
+// We also set doubleSided=true to fix backface culling with negative-X scaling.
 async function patchGltfAddIndices(gltfUrl) {
     const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
     const json = await fetch(gltfUrl).then(r => r.json());
     const prim = json.meshes[0].primitives[0];
-    if (prim.indices != null) return gltfUrl;
 
     const makeAbsolute = uri =>
         (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
     for (const buf of json.buffers ?? []) { if (buf.uri) buf.uri = makeAbsolute(buf.uri); }
     for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
 
+    for (const mat of json.materials ?? []) mat.doubleSided = true;
+
+    const toBase64 = (typedArray) => {
+        const bytes = new Uint8Array(typedArray.buffer);
+        let binary = "";
+        const chunk = 8192;
+        for (let i = 0; i < bytes.length; i += chunk)
+            binary += String.fromCharCode(...bytes.subarray(i, Math.min(i + chunk, bytes.length)));
+        return btoa(binary);
+    };
+
     const vertexCount = json.accessors[prim.attributes.POSITION].count;
-    const indices = new Uint16Array(vertexCount);
-    for (let i = 0; i < vertexCount; i++) indices[i] = i;
 
-    const bytes = new Uint8Array(indices.buffer);
-    let binary = "";
-    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    if (prim.indices == null) {
+        const indices = new Uint16Array(vertexCount);
+        for (let i = 0; i < vertexCount; i++) indices[i] = i;
+        const bufIdx = json.buffers.length;
+        json.buffers.push({ uri: "data:application/octet-stream;base64," + toBase64(indices), byteLength: indices.byteLength });
+        const bvIdx = json.bufferViews.length;
+        json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
+        const accIdx = json.accessors.length;
+        json.accessors.push({ bufferView: bvIdx, componentType: 5123, count: vertexCount, type: "SCALAR" });
+        prim.indices = accIdx;
+    }
 
-    const bufIdx = json.buffers.length;
-    json.buffers.push({ uri: "data:application/octet-stream;base64," + btoa(binary), byteLength: indices.byteLength });
-    const bvIdx = json.bufferViews.length;
-    json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
-    const accIdx = json.accessors.length;
-    json.accessors.push({ bufferView: bvIdx, componentType: 5123, count: vertexCount, type: "SCALAR" });
-    prim.indices = accIdx;
+    if (prim.attributes.NORMAL == null) {
+        // Fetch position data to compute proper flat normals
+        const posAcc = json.accessors[prim.attributes.POSITION];
+        const posBv = json.bufferViews[posAcc.bufferView];
+        const binData = await fetch(json.buffers[posBv.buffer].uri).then(r => r.arrayBuffer());
+        const stride = posBv.byteStride || 12;
+        const posBase = (posBv.byteOffset ?? 0) + (posAcc.byteOffset ?? 0);
+        const view = new DataView(binData);
+        const getPos = (i) => [
+            view.getFloat32(posBase + i * stride, true),
+            view.getFloat32(posBase + i * stride + 4, true),
+            view.getFloat32(posBase + i * stride + 8, true),
+        ];
+
+        const normals = new Float32Array(vertexCount * 3);
+        for (let tri = 0; tri < vertexCount / 3; tri++) {
+            const [ax, ay, az] = getPos(tri * 3);
+            const [bx, by, bz] = getPos(tri * 3 + 1);
+            const [cx, cy, cz] = getPos(tri * 3 + 2);
+            const dx = bx - ax, dy = by - ay, dz = bz - az;
+            const ex = cx - ax, ey = cy - ay, ez = cz - az;
+            let nx = dy * ez - dz * ey, ny = dz * ex - dx * ez, nz = dx * ey - dy * ex;
+            const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+            if (len > 1e-10) { nx /= len; ny /= len; nz /= len; }
+            for (let j = 0; j < 3; j++) {
+                normals[(tri * 3 + j) * 3]     = nx;
+                normals[(tri * 3 + j) * 3 + 1] = ny;
+                normals[(tri * 3 + j) * 3 + 2] = nz;
+            }
+        }
+        const normBufIdx = json.buffers.length;
+        json.buffers.push({ uri: "data:application/octet-stream;base64," + toBase64(normals), byteLength: normals.byteLength });
+        const normBvIdx = json.bufferViews.length;
+        json.bufferViews.push({ buffer: normBufIdx, byteOffset: 0, byteLength: normals.byteLength });
+        const normAccIdx = json.accessors.length;
+        json.accessors.push({ bufferView: normBvIdx, componentType: 5126, count: vertexCount, type: "VEC3" });
+        prim.attributes.NORMAL = normAccIdx;
+        console.log("[Fox patch] Added synthetic flat normals, vertexCount:", vertexCount);
+    }
 
     const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
     return URL.createObjectURL(blob);
@@ -82,9 +131,9 @@ async function init() {
 
     URL.revokeObjectURL(foxGltfUrl);
 
-    // Quick Fox sanity check
     const foxMesh = foxAsset.entities[0]?.children?.[1]?.children?.[0];
-    console.log("[Fox] mesh indexCount:", foxMesh?._gpu?.indexCount, "material:", !!foxMesh?.material);
+    console.log("[Fox] mesh indexCount:", foxMesh?._gpu?.indexCount,
+        "hasNormal:", !!(foxMesh?._gpu?.normalBuffer), "material:", !!foxMesh?.material);
 
     const truckRoot = truckAsset.entities[0];
     truckRoot.scaling.set(-0.4, 0.4, 0.4);
@@ -112,21 +161,11 @@ async function init() {
     foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     foxRoot.position.set(0, 0, 0);
     addToScene(scene, foxAsset);
-    // Stop ALL animations to test bind pose visibility
-    for (const ag of foxAsset.animationGroups ?? []) stopAnimation(ag);
-    console.log("[Fox] all animations stopped. animationGroups:",
-        foxAsset.animationGroups?.map(ag => `${ag.name} stopped=${ag._stopped}`));
-
-    // Log Fox mesh world matrix after first render to confirm world position
-    let foxFrameCount = 0;
-    const foxMeshNode = foxAsset.entities[0]?.children?.[1]?.children?.[0];
-    onBeforeRender(scene, () => {
-        if (foxFrameCount++ === 2 && foxMeshNode) {
-            const wm = foxMeshNode.worldMatrix;
-            console.log("[Fox] worldMatrix after 2 frames:", wm ? Array.from(wm).map(v => v.toFixed(3)).join(",") : "(none)");
-            console.log("[Fox] foxRoot.position:", foxRoot.position, "scaling:", foxRoot.scaling);
-        }
-    });
+    if (foxAsset.animationGroups?.length >= 3) {
+        stopAnimation(foxAsset.animationGroups[0]); // Survey
+        stopAnimation(foxAsset.animationGroups[1]); // Walk
+        // animationGroups[2] = Run — keep playing
+    }
 
     const trexRoot = trexAsset.entities[0];
     trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -29,6 +29,50 @@ const CAM_BETA = Math.acos(5 / CAM_RADIUS);
 // Quaternion for 90 degree rotation around Y axis
 const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
 
+// Fox.gltf has no `indices` field (non-indexed geometry).
+// Babylon.js Lite only supports drawIndexed(), so we patch the GLTF at runtime
+// to add sequential indices [0, 1, 2, ..., N-1] and return a Blob URL.
+async function patchGltfAddIndices(gltfUrl) {
+    const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
+    const json = await fetch(gltfUrl).then(r => r.json());
+
+    const prim = json.meshes[0].primitives[0];
+    if (prim.indices != null) return gltfUrl; // already indexed, no patch needed
+
+    // Make existing buffer URIs absolute so they resolve from the Blob URL
+    for (const buf of json.buffers ?? []) {
+        if (buf.uri && !buf.uri.startsWith("data:") && !buf.uri.startsWith("http")) {
+            buf.uri = baseUrl + buf.uri;
+        }
+    }
+
+    const vertexCount = json.accessors[prim.attributes.POSITION].count;
+
+    // Build sequential UINT16 index buffer [0, 1, 2, ..., vertexCount-1]
+    const indices = new Uint16Array(vertexCount);
+    for (let i = 0; i < vertexCount; i++) indices[i] = i;
+
+    // Encode as base64 data URI
+    const bytes = new Uint8Array(indices.buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    const dataUri = "data:application/octet-stream;base64," + btoa(binary);
+
+    const bufIdx = json.buffers.length;
+    json.buffers.push({ uri: dataUri, byteLength: indices.byteLength });
+
+    const bvIdx = json.bufferViews.length;
+    json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
+
+    const accIdx = json.accessors.length;
+    json.accessors.push({ bufferView: bvIdx, componentType: 5123 /* UNSIGNED_SHORT */, count: vertexCount, type: "SCALAR" });
+
+    prim.indices = accIdx;
+
+    const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
+    return URL.createObjectURL(blob);
+}
+
 async function init() {
     const canvas = document.querySelector("#c");
     const engine = await createEngine(canvas);
@@ -38,11 +82,17 @@ async function init() {
     scene.camera = cam;
     attachControl(cam, canvas, scene);
 
+    const foxUrl = await patchGltfAddIndices(
+        "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"
+    );
+
     const [truckAsset, foxAsset, trexAsset] = await Promise.all([
         loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf"),
-        loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"),
+        loadGltf(engine, foxUrl),
         loadGltf(engine, "https://raw.githubusercontent.com/BabylonJS/Exporters/d66db9a7042fef66acb62e1b8770739463b0b567/Maya/Samples/glTF%202.0/T-Rex/trex.gltf"),
     ]);
+
+    URL.revokeObjectURL(foxUrl);
 
     // AssetContainer root is entities[0]: a TransformNode with scaling (-1,1,1)
     // Preserve the -1 x-scale when applying model scale: set(-scale, scale, scale)
@@ -53,10 +103,6 @@ async function init() {
     truckRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     truckRoot.position.set(0, 0, 2);
     addToScene(scene, truckAsset);
-
-    console.group("[Truck] entity tree (no skin - for comparison)");
-    truckAsset.entities?.forEach(e => inspectTree(e));
-    console.groupEnd();
 
     // Wheel tracks: two thin planes in the XZ plane (rotated from XY)
     // Matching Babylon.js: CreatePlane({width:100, height:0.1}), rotated PI/2 around X
@@ -76,35 +122,6 @@ async function init() {
     track2.material = trackMaterial;
     addToScene(scene, track2);
 
-    // ---- Fox debug ----
-    function inspectTree(node, depth = 0) {
-        const indent = "  ".repeat(depth);
-        const hasGpu = "_gpu" in node;
-        const hasMat = "material" in node;
-        const children = node.children ?? [];
-        let line = `${indent}[${depth}] "${node.name}" _gpu=${hasGpu} material=${hasMat} children=${children.length}`;
-        if (hasGpu && node._gpu) {
-            const g = node._gpu;
-            const gkeys = Object.keys(g);
-            const idxCount = g.indexCount ?? g.indicesCount ?? g.indexBuffer?.size ?? "(n/a)";
-            line += ` | gpu keys:[${gkeys.join(",")}] indexCount=${idxCount}`;
-        }
-        if (hasMat && node.material) {
-            const bg = node.material._buildGroup;
-            line += ` | _buildGroup=${bg === null ? "null" : bg === undefined ? "undefined" : "SET"}`;
-            line += ` | mat keys:[${Object.keys(node.material).join(",")}]`;
-        }
-        if ("skeleton" in node && node.skeleton) {
-            line += ` | skeleton boneCount=${node.skeleton.boneCount}`;
-        }
-        console.log(line);
-        for (const child of children) inspectTree(child, depth + 1);
-    }
-
-    console.group("[Fox] entity tree");
-    foxAsset.entities?.forEach(e => inspectTree(e));
-    console.groupEnd();
-
     // Fox (GLtF animations: Survey[0], Walk[1], Run[2])
     // addToScene auto-registers and plays all animation groups;
     // stop Survey and Walk so only Run plays (matches Babylon.js animationGroups[2].play(true))
@@ -113,17 +130,12 @@ async function init() {
     foxRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     foxRoot.position.set(0, 0, 0);
     addToScene(scene, foxAsset);
-
     if (foxAsset.animationGroups?.length >= 3) {
         stopAnimation(foxAsset.animationGroups[0]); // Survey
         stopAnimation(foxAsset.animationGroups[1]); // Walk
     }
 
     // T-Rex
-    console.group("[T-Rex] entity tree (for comparison)");
-    trexAsset.entities?.forEach(e => inspectTree(e));
-    console.groupEnd();
-
     const trexRoot = trexAsset.entities[0];
     trexRoot.rotationQuaternion.set(Q_Y90.x, Q_Y90.y, Q_Y90.z, Q_Y90.w);
     trexRoot.position.set(0, 0, -3);
@@ -154,13 +166,6 @@ async function init() {
     });
 
     await registerScene(scene);
-
-    // ---- post-register debug ----
-    console.group("[Fox] entity tree after registerScene");
-    foxAsset.entities?.forEach(e => inspectTree(e));
-    console.groupEnd();
-    // ---- end post-register debug ----
-
     await startEngine(engine);
 }
 

--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -73,24 +73,40 @@ async function init() {
     addToScene(scene, track2);
 
     // ---- Fox debug ----
+    function inspectNode(node, depth = 0) {
+        const indent = "  ".repeat(depth);
+        const hasMesh = "_gpu" in node && "material" in node;
+        const gpu = node._gpu;
+        console.log(
+            `${indent}[${depth}] name="${node.name}" _gpu=${hasMesh ? "YES" : "no"}` +
+            ` material=${node.material ? node.material.constructor?.name ?? "object" : "none"}` +
+            ` skeleton=${node.skeleton ? "YES" : "no"}` +
+            ` _children=${node._children?.length ?? 0}`
+        );
+        if (gpu) {
+            console.log(`${indent}    gpu.indexBuffer=`, gpu.indexBuffer ?? "(none)");
+            console.log(`${indent}    gpu.vertexBuffers=`, gpu.vertexBuffers ?? "(none)");
+            console.log(`${indent}    gpu.indexCount=`, gpu.indexCount ?? gpu.indicesCount ?? "(n/a)");
+            console.log(`${indent}    gpu keys:`, Object.keys(gpu));
+        }
+        if (node.material) {
+            console.log(`${indent}    material keys:`, Object.keys(node.material));
+            console.log(`${indent}    material._buildGroup=`, node.material._buildGroup ?? "(null)");
+        }
+        if (node.skeleton) {
+            console.log(`${indent}    skeleton keys:`, Object.keys(node.skeleton));
+            console.log(`${indent}    skeleton.boneCount=`, node.skeleton.boneCount);
+        }
+        for (const child of node._children ?? []) {
+            inspectNode(child, depth + 1);
+        }
+    }
+
     console.group("[Fox] loadGltf result");
     console.log("foxAsset keys:", Object.keys(foxAsset));
     console.log("foxAsset.entities.length:", foxAsset.entities?.length);
-    foxAsset.entities?.forEach((e, i) => {
-        const keys = Object.keys(e);
-        console.group(`  entity[${i}] name="${e.name ?? "(none)"}" constructor=${e.constructor?.name}`);
-        console.log("  keys:", keys);
-        console.log("  has _gpu:", "_gpu" in e);
-        console.log("  has material:", "material" in e);
-        console.log("  has skeleton:", "skeleton" in e);
-        console.log("  material:", e.material ?? null);
-        console.log("  skeleton:", e.skeleton ?? null);
-        console.log("  position:", e.position);
-        console.log("  scaling:", e.scaling);
-        console.log("  visibility:", e.visibility ?? "(n/a)");
-        console.log("  isEnabled:", typeof e.isEnabled === "function" ? e.isEnabled() : e.isEnabled ?? "(n/a)");
-        console.groupEnd();
-    });
+    console.log("--- entity tree ---");
+    foxAsset.entities?.forEach(e => inspectNode(e));
     console.log("animationGroups:", foxAsset.animationGroups?.map((ag, i) =>
         `[${i}] name="${ag.name}" stopped=${ag._stopped} isPlaying=${ag.isPlaying}`
     ));
@@ -106,24 +122,9 @@ async function init() {
     foxRoot.position.set(0, 0, 0);
     addToScene(scene, foxAsset);
 
-    console.group("[Fox] after addToScene");
-    console.log("scene._meshes count:", scene._meshes?.length ?? scene.meshes?.length ?? "(unknown key)");
-    // Check all scene collections for Fox entities
-    for (const key of Object.keys(scene)) {
-        const val = scene[key];
-        if (Array.isArray(val) && val.length > 0 && val.some(x => x && typeof x === "object" && x.name?.startsWith("Fox"))) {
-            console.log(`  scene.${key} has Fox entries:`, val.filter(x => x?.name?.startsWith("Fox")).map(x => x.name));
-        }
-    }
-    console.groupEnd();
-
     if (foxAsset.animationGroups?.length >= 3) {
         stopAnimation(foxAsset.animationGroups[0]); // Survey
         stopAnimation(foxAsset.animationGroups[1]); // Walk
-        console.log("[Fox] stopped Survey and Walk; Run state:", {
-            stopped: foxAsset.animationGroups[2]._stopped,
-            isPlaying: foxAsset.animationGroups[2].isPlaying,
-        });
     }
 
     // T-Rex
@@ -162,11 +163,8 @@ async function init() {
     console.group("[Fox] after registerScene");
     console.log("scene._renderables count:", scene._renderables?.length ?? "(unknown)");
     console.log("scene._deferredBuilders remaining:", scene._deferredBuilders?.length ?? 0);
-    const foxEntities = foxAsset.entities ?? [];
-    foxEntities.forEach((e, i) => {
-        console.log(`  fox entity[${i}] name="${e.name}" material._buildGroup:`,
-            e.material?._buildGroup ?? "(no material or _buildGroup)");
-    });
+    console.log("--- Fox entity tree after registerScene ---");
+    foxAsset.entities?.forEach(e => inspectNode(e));
     console.groupEnd();
     // ---- end post-register debug ----
 


### PR DESCRIPTION
## Summary

- Add Babylon.js Lite (WebGPU-only engine) sample pages: triangle, square, cube, texture, teapot, primitive, complex
- Complex example includes CesiumMilkTruck (with wheel tracks), Fox (animated), and T-Rex rendered via `loadGltf`
- Uses IBL environment (`loadEnvironment`) and skybox (`loadSkybox`) for PBR lighting
- Camera position matches the existing Babylon.js complex sample

## Known Limitations

- **Fox is not visible** in the complex example. `Fox.gltf` uses non-indexed geometry (no `indices` field), which Babylon.js Lite v1.0.1 does not support. A runtime patch (`patchGltfForLite`) is included that adds sequential indices, synthesizes flat normals, and sets `doubleSided=true`, but the model still does not render correctly due to engine limitations.

## Test plan

- [ ] Open each sample page and verify it renders without errors
- [ ] Complex example: CesiumMilkTruck and T-Rex should be visible with lighting; camera auto-rotates
- [ ] All samples require a WebGPU-capable browser (Chrome 113+, Edge 113+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)