### PR TITLE
Update @babylonjs/lite from 1.0.1 to 1.2.0

### DIFF
--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -15,7 +15,7 @@ import {
     registerScene,
     startEngine,
     stopAnimation,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
 const BRDF_URL = "https://raw.githubusercontent.com/BabylonJS/Babylon-Lite/master/lab/public/brdf-lut.png";

--- a/examples/babylonjs-lite/cube/index.js
+++ b/examples/babylonjs-lite/cube/index.js
@@ -8,7 +8,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,

--- a/examples/babylonjs-lite/primitive/index.js
+++ b/examples/babylonjs-lite/primitive/index.js
@@ -17,7 +17,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylonjs-lite/square/index.js
+++ b/examples/babylonjs-lite/square/index.js
@@ -7,7 +7,7 @@ import {
     createShaderMaterial,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,

--- a/examples/babylonjs-lite/teapot/index.js
+++ b/examples/babylonjs-lite/teapot/index.js
@@ -10,7 +10,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylonjs-lite/texture/index.js
+++ b/examples/babylonjs-lite/texture/index.js
@@ -9,7 +9,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylonjs-lite/triangles/index.js
+++ b/examples/babylonjs-lite/triangles/index.js
@@ -7,7 +7,7 @@ import {
     createShaderMaterial,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.0.1";
+} from "https://esm.sh/@babylonjs/lite@1.2.0";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,


### PR DESCRIPTION
## Summary
Bump the `@babylonjs/lite` esm.sh import from `1.0.1` to `1.2.0` across all babylonjs-lite examples.

## Changes
- `examples/babylonjs-lite/{complex,cube,primitive,square,teapot,texture,triangles}/index.js`
- Each file: 1 line (the esm.sh import URL version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)