### PR TITLE
Load Fox.gltf directly now that Babylon.js Lite 1.2.0 supports it

### DIFF
--- a/examples/babylonjs-lite/complex/index.js
+++ b/examples/babylonjs-lite/complex/index.js
@@ -27,90 +27,6 @@ const CAM_BETA = Math.acos(5 / CAM_RADIUS);
 // Quaternion for 90 degree rotation around Y axis
 const Q_Y90 = { x: 0, y: Math.sin(Math.PI / 4), z: 0, w: Math.cos(Math.PI / 4) };
 
-// Fox.gltf has no `indices` field (non-indexed geometry).
-// Babylon.js Lite only supports drawIndexed(), so we patch at runtime:
-//   - add sequential indices [0..N-1]
-//   - synthesize flat normals from POSITION data (NORMAL attribute is absent)
-//   - set doubleSided=true to prevent backface culling with negative-X scale
-// NOTE: Despite these patches, Fox is not rendered correctly in Babylon.js Lite v1.0.1.
-//       Non-indexed glTF geometry is a known limitation of this engine version.
-async function patchGltfForLite(gltfUrl) {
-    const baseUrl = gltfUrl.substring(0, gltfUrl.lastIndexOf("/") + 1);
-    const json = await fetch(gltfUrl).then(r => r.json());
-    const prim = json.meshes[0].primitives[0];
-
-    const makeAbsolute = uri =>
-        (uri && !uri.startsWith("data:") && !uri.match(/^https?:\/\//) ? baseUrl + uri : uri);
-    for (const buf of json.buffers ?? []) { if (buf.uri) buf.uri = makeAbsolute(buf.uri); }
-    for (const img of json.images ?? []) { if (img.uri) img.uri = makeAbsolute(img.uri); }
-
-    for (const mat of json.materials ?? []) mat.doubleSided = true;
-
-    const toBase64 = (typedArray) => {
-        const bytes = new Uint8Array(typedArray.buffer);
-        let binary = "";
-        const chunk = 8192;
-        for (let i = 0; i < bytes.length; i += chunk)
-            binary += String.fromCharCode(...bytes.subarray(i, Math.min(i + chunk, bytes.length)));
-        return btoa(binary);
-    };
-
-    const vertexCount = json.accessors[prim.attributes.POSITION].count;
-
-    if (prim.indices == null) {
-        const indices = new Uint16Array(vertexCount);
-        for (let i = 0; i < vertexCount; i++) indices[i] = i;
-        const bufIdx = json.buffers.length;
-        json.buffers.push({ uri: "data:application/octet-stream;base64," + toBase64(indices), byteLength: indices.byteLength });
-        const bvIdx = json.bufferViews.length;
-        json.bufferViews.push({ buffer: bufIdx, byteOffset: 0, byteLength: indices.byteLength });
-        const accIdx = json.accessors.length;
-        json.accessors.push({ bufferView: bvIdx, componentType: 5123, count: vertexCount, type: "SCALAR" });
-        prim.indices = accIdx;
-    }
-
-    if (prim.attributes.NORMAL == null) {
-        const posAcc = json.accessors[prim.attributes.POSITION];
-        const posBv = json.bufferViews[posAcc.bufferView];
-        const binData = await fetch(json.buffers[posBv.buffer].uri).then(r => r.arrayBuffer());
-        const stride = posBv.byteStride || 12;
-        const posBase = (posBv.byteOffset ?? 0) + (posAcc.byteOffset ?? 0);
-        const view = new DataView(binData);
-        const getPos = (i) => [
-            view.getFloat32(posBase + i * stride, true),
-            view.getFloat32(posBase + i * stride + 4, true),
-            view.getFloat32(posBase + i * stride + 8, true),
-        ];
-
-        const normals = new Float32Array(vertexCount * 3);
-        for (let tri = 0; tri < vertexCount / 3; tri++) {
-            const [ax, ay, az] = getPos(tri * 3);
-            const [bx, by, bz] = getPos(tri * 3 + 1);
-            const [cx, cy, cz] = getPos(tri * 3 + 2);
-            const dx = bx - ax, dy = by - ay, dz = bz - az;
-            const ex = cx - ax, ey = cy - ay, ez = cz - az;
-            let nx = dy * ez - dz * ey, ny = dz * ex - dx * ez, nz = dx * ey - dy * ex;
-            const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-            if (len > 1e-10) { nx /= len; ny /= len; nz /= len; }
-            for (let j = 0; j < 3; j++) {
-                normals[(tri * 3 + j) * 3]     = nx;
-                normals[(tri * 3 + j) * 3 + 1] = ny;
-                normals[(tri * 3 + j) * 3 + 2] = nz;
-            }
-        }
-        const normBufIdx = json.buffers.length;
-        json.buffers.push({ uri: "data:application/octet-stream;base64," + toBase64(normals), byteLength: normals.byteLength });
-        const normBvIdx = json.bufferViews.length;
-        json.bufferViews.push({ buffer: normBufIdx, byteOffset: 0, byteLength: normals.byteLength });
-        const normAccIdx = json.accessors.length;
-        json.accessors.push({ bufferView: normBvIdx, componentType: 5126, count: vertexCount, type: "VEC3" });
-        prim.attributes.NORMAL = normAccIdx;
-    }
-
-    const blob = new Blob([JSON.stringify(json)], { type: "model/gltf+json" });
-    return URL.createObjectURL(blob);
-}
-
 async function init() {
     const canvas = document.querySelector("#c");
     const engine = await createEngine(canvas);
@@ -120,17 +36,11 @@ async function init() {
     scene.camera = cam;
     attachControl(cam, canvas, scene);
 
-    const foxGltfUrl = await patchGltfForLite(
-        "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"
-    );
-
     const [truckAsset, foxAsset, trexAsset] = await Promise.all([
         loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf"),
-        loadGltf(engine, foxGltfUrl),
+        loadGltf(engine, "https://cx20.github.io/gltf-test/sampleModels/Fox/glTF/Fox.gltf"),
         loadGltf(engine, "https://raw.githubusercontent.com/BabylonJS/Exporters/d66db9a7042fef66acb62e1b8770739463b0b567/Maya/Samples/glTF%202.0/T-Rex/trex.gltf"),
     ]);
-
-    URL.revokeObjectURL(foxGltfUrl);
 
     const truckRoot = truckAsset.entities[0];
     truckRoot.scaling.set(-0.4, 0.4, 0.4);


### PR DESCRIPTION
## Summary
Babylon.js Lite 1.2.0 now handles non-indexed glTF geometry natively. The runtime workaround in the `complex` example (`patchGltfForLite`) is no longer required, so Fox.gltf can be loaded directly.

## Changes
- Remove the `patchGltfForLite` helper that added sequential indices, synthesized flat normals, and forced `doubleSided` to work around Babylon.js Lite v1.0.1 limitations.
- Load `Fox.gltf` directly via `loadGltf` in the complex example.

## Context
This follows up #197 (bump `@babylonjs/lite` to 1.2.0). With the engine update, Fox.gltf renders correctly without patching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)