### PR TITLE
Update Rhodonite from v0.19.2 to v0.19.8

### DIFF
--- a/examples/rhodonite/complex/index.html
+++ b/examples/rhodonite/complex/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/cube/index.html
+++ b/examples/rhodonite/cube/index.html
@@ -8,7 +8,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/primitive/index.html
+++ b/examples/rhodonite/primitive/index.html
@@ -8,7 +8,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/square/index.html
+++ b/examples/rhodonite/square/index.html
@@ -8,7 +8,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/teapot/index.html
+++ b/examples/rhodonite/teapot/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/texture/index.html
+++ b/examples/rhodonite/texture/index.html
@@ -8,7 +8,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/triangle/index.html
+++ b/examples/rhodonite/triangle/index.html
@@ -8,7 +8,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
     }
 }
 </script>


### PR DESCRIPTION
Bump the Rhodonite import map URL from `v0.19.2` to `v0.19.8` across all Rhodonite WebGPU samples.

## Updated files
- examples/rhodonite/triangle/index.html
- examples/rhodonite/teapot/index.html
- examples/rhodonite/texture/index.html
- examples/rhodonite/complex/index.html
- examples/rhodonite/cube/index.html
- examples/rhodonite/primitive/index.html
- examples/rhodonite/square/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)