### PR TITLE
Update Babylon Lite to v1.3.0 and use import maps

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/complex/index.js
+++ b/examples/babylon-lite/complex/index.js
@@ -15,7 +15,7 @@ import {
     registerScene,
     startEngine,
     stopAnimation,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
 const BRDF_URL = "https://raw.githubusercontent.com/BabylonJS/Babylon-Lite/master/lab/public/brdf-lut.png";

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/cube/index.js
+++ b/examples/babylon-lite/cube/index.js
@@ -8,7 +8,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/primitive/index.js
+++ b/examples/babylon-lite/primitive/index.js
@@ -17,7 +17,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/square/index.js
+++ b/examples/babylon-lite/square/index.js
@@ -7,7 +7,7 @@ import {
     createShaderMaterial,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/teapot/index.js
+++ b/examples/babylon-lite/teapot/index.js
@@ -10,7 +10,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/texture/index.js
+++ b/examples/babylon-lite/texture/index.js
@@ -9,7 +9,7 @@ import {
     onBeforeRender,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 async function init() {
     const canvas = document.querySelector("#c");

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -7,6 +7,13 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylon-lite/triangles/index.js
+++ b/examples/babylon-lite/triangles/index.js
@@ -7,7 +7,7 @@ import {
     createShaderMaterial,
     registerScene,
     startEngine,
-} from "https://esm.sh/@babylonjs/lite@1.2.0";
+} from "@babylonjs/lite";
 
 const vertexSource = `struct VertexOutput {
   @builtin(position) position: vec4<f32>,


### PR DESCRIPTION
## Summary
- Bump `@babylonjs/lite` from `1.2.0` to `1.3.0` across all Babylon Lite samples.
- Move the version specifier out of each `index.js` and into an import map in `index.html`, so `index.js` imports from the bare `@babylonjs/lite` specifier and the version is managed in one place per sample.

## Affected samples
complex, cube, primitive, square, teapot, texture, triangles

🤖 Generated with [Claude Code](https://claude.com/claude-code)