### PR TITLE
Update Babylon Lite to v1.4.0 and fix Fox animation

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/complex/index.js
+++ b/examples/babylon-lite/complex/index.js
@@ -12,6 +12,7 @@ import {
     loadGltf,
     loadSkybox,
     onBeforeRender,
+    playAnimation,
     registerScene,
     startEngine,
     stopAnimation,
@@ -71,7 +72,7 @@ async function init() {
     if (foxAsset.animationGroups?.length >= 3) {
         stopAnimation(foxAsset.animationGroups[0]); // Survey
         stopAnimation(foxAsset.animationGroups[1]); // Walk
-        // animationGroups[2] = Run
+        playAnimation(foxAsset.animationGroups[2]); // Run
     }
 
     const trexRoot = trexAsset.entities[0];

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.3.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0"
   }
 }
 </script>


### PR DESCRIPTION
## Summary

- Bump `@babylonjs/lite` from `1.3.0` to `1.4.0` across all babylon-lite samples (complex, cube, primitive, square, teapot, texture, triangles).
- Fix the Fox no longer animating in the complex sample after the upgrade.

## Why the Fox stopped animating

In v1.4.0 the glTF loader changed its default animation behavior:

| | v1.3.0 | v1.4.0 |
|---|---|---|
| Auto-play | all animation groups | first group (index 0) only |

The complex sample only stopped the `Survey` and `Walk` groups and relied on the `Run` group already playing. Under v1.4.0 the `Run` group is never started, so the Fox stays still.

## Fix

Explicitly start the `Run` animation group via `playAnimation()`, matching the original Babylon.js sample (`animationGroups[2].play(true)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)