### PR TITLE
Add ?bundle to Babylon Lite importmap

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Append `?bundle` to the esm.sh `@babylonjs/lite@1.6.0` import across all 7 Babylon Lite examples (complex, cube, primitive, square, teapot, texture, triangles).

## Reason
See cx20/gltf-test#954 — using the `?bundle` query avoids module resolution issues by serving a self-contained bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)