### PR TITLE
Migrate RedGPU samples to the new RedGPU API

### DIFF
--- a/examples/redgpu/cube/index.html
+++ b/examples/redgpu/cube/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <title>Testing WebGPU Cube Using RedGPU</title>
     <link rel="stylesheet" type="text/css" href="style.css">
-    <script src="https://raw.githubusercontent.com/redcamel/RedGPU/e36d372368e4c3de7dc14d00c6035a5126747913/libs/gl-matrix-min.js"></script>
-    <script src="https://raw.githubusercontent.com/redcamel/RedGPU/e36d372368e4c3de7dc14d00c6035a5126747913/libs/dat.gui.min.js"></script>
   </head>
 <body>
 <canvas id="canvas"></canvas>

--- a/examples/redgpu/cube/index.js
+++ b/examples/redgpu/cube/index.js
@@ -1,161 +1,107 @@
-import RedGPU from "https://redcamel.github.io/RedGPU/src/RedGPU.js";
+import * as RedGPU from "https://redcamel.github.io/RedGPU/dist/index.js";
 
-const c = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
+canvas.width = 512;
+canvas.height = 512;
 
-class VertexColorMaterial extends RedGPU.BaseMaterial {
-    static vertexShaderGLSL = `
-    #version 460
-    ${RedGPU.ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    ${RedGPU.ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-    layout(location = 0) in vec3 position;
-    layout(location = 1) in vec4 vertexColor;
-    layout(location = 0) out vec4 vVertexColor;
-    void main() {
-        gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
-        vVertexColor = vertexColor;
-    }
-    `;
-    static fragmentShaderGLSL = `
-    #version 460
-    layout(location = 0) in vec4 vVertexColor;
-    layout(location = 0) out vec4 outColor;
-    layout(location = 1) out vec4 out_MouseColorID_Depth;
-    void main() {
-        outColor = vVertexColor;
-    }
-    `;
-    static PROGRAM_OPTION_LIST = {
-        vertex: [],
-        fragment: []
-    };
-    static uniformsBindGroupLayoutDescriptor_material = {
-        entries: []
-    };
-    static uniformBufferDescriptor_vertex = RedGPU.BaseMaterial.uniformBufferDescriptor_empty;
-    static uniformBufferDescriptor_fragment = RedGPU.BaseMaterial.uniformBufferDescriptor_empty;
+RedGPU.init(
+    canvas,
+    (redGPUContext) => {
+        const controller = new RedGPU.Camera.OrbitController(redGPUContext);
+        controller.distance = 3;
+        controller.tilt = -20;
 
-    constructor(redGPU) {
-        super(redGPU);
-        this.resetBindingInfo()
-    }
+        const scene = new RedGPU.Display.Scene();
+        scene.useBackgroundColor = true;
+        scene.backgroundColor.setColorByHEX('#ffffff');
 
-    resetBindingInfo() {
-        this.entries = [];
-        this._afterResetBindingInfo();
-    }
-}
+        const view = new RedGPU.Display.View3D(redGPUContext, scene, controller);
+        redGPUContext.addView(view);
 
-new RedGPU.RedGPUContext(c,
-    function () {
-        let tScene = new RedGPU.Scene();
-        tScene.backgroundColor = '#fff';
-
-        let tCamera = new RedGPU.ObitController(this);
-        let tView = new RedGPU.View(this, tScene, tCamera);
-        this.addView(tView);
-        tCamera.distance = 2;
-        tCamera.tilt = 0;
-
-        this.setSize(window.innerWidth, window.innerHeight);
-
-        // Cube data
-        //             1.0 y 
-        //              ^  -1.0 
-        //              | / z
-        //              |/       x
-        // -1.0 -----------------> +1.0
-        //            / |
-        //      +1.0 /  |
-        //           -1.0
-        // 
-        //         [7]------[6]
-        //        / |      / |
-        //      [3]------[2] |
-        //       |  |     |  |
-        //       | [4]----|-[5]
-        //       |/       |/
-        //      [0]------[1]
-        //
-        let interleaveData = new Float32Array(
-            [
-                // x,   y,   z,    r,   g,   b,  a
-
-                // Front face
-                -0.5, -0.5,  0.5,  1.0, 0.0, 0.0, 1.0, // v0
-                 0.5, -0.5,  0.5,  1.0, 0.0, 0.0, 1.0, // v1
-                 0.5,  0.5,  0.5,  1.0, 0.0, 0.0, 1.0, // v2
-                -0.5,  0.5,  0.5,  1.0, 0.0, 0.0, 1.0, // v3
-                // Back face
-                -0.5, -0.5, -0.5,  1.0, 1.0, 0.0, 1.0, // v4
-                 0.5, -0.5, -0.5,  1.0, 1.0, 0.0, 1.0, // v5
-                 0.5,  0.5, -0.5,  1.0, 1.0, 0.0, 1.0, // v6
-                -0.5,  0.5, -0.5,  1.0, 1.0, 0.0, 1.0, // v7
-                // Top face
-                 0.5,  0.5,  0.5,  0.0, 1.0, 0.0, 1.0, // v2
-                -0.5,  0.5,  0.5,  0.0, 1.0, 0.0, 1.0, // v3
-                -0.5,  0.5, -0.5,  0.0, 1.0, 0.0, 1.0, // v7
-                 0.5,  0.5, -0.5,  0.0, 1.0, 0.0, 1.0, // v6
-                // Bottom face
-                -0.5, -0.5,  0.5,  1.0, 0.5, 0.5, 1.0, // v0
-                 0.5, -0.5,  0.5,  1.0, 0.5, 0.5, 1.0, // v1
-                 0.5, -0.5, -0.5,  1.0, 0.5, 0.5, 1.0, // v5
-                -0.5, -0.5, -0.5,  1.0, 0.5, 0.5, 1.0, // v4
-                 // Right face
-                 0.5, -0.5,  0.5,  1.0, 0.0, 1.0, 1.0, // v1
-                 0.5,  0.5,  0.5,  1.0, 0.0, 1.0, 1.0, // v2
-                 0.5,  0.5, -0.5,  1.0, 0.0, 1.0, 1.0, // v6
-                 0.5, -0.5, -0.5,  1.0, 0.0, 1.0, 1.0, // v5
-                 // Left face
-                -0.5, -0.5,  0.5,  0.0, 0.0, 1.0, 1.0, // v0
-                -0.5,  0.5,  0.5,  0.0, 0.0, 1.0, 1.0, // v3
-                -0.5,  0.5, -0.5,  0.0, 0.0, 1.0, 1.0, // v7
-                -0.5, -0.5, -0.5,  0.0, 0.0, 1.0, 1.0  // v4
-            ]
-        );
-        let indexData = new Uint32Array(
-            [
-                 0,  1,  2,    0,  2 , 3,  // Front face
-                 4,  5,  6,    4,  6 , 7,  // Back face
-                 8,  9, 10,    8, 10, 11,  // Top face
-                12, 13, 14,   12, 14, 15,  // Bottom face
-                16, 17, 18,   16, 18, 19,  // Right face
-                20, 21, 22,   20, 22, 23   // Left face
-            ]
+        // RedGPU delivers a per-vertex color (vertexColor_0) to the fragment shader
+        // only through the PBR vertex path, which is selected when the geometry's
+        // interleaved struct is labeled 'PBR'. So we build a full PBR vertex layout
+        // (position / normal / uv / uv1 / color / tangent) and assign one color per face.
+        const VC = RedGPU.Resource.VertexInterleaveType;
+        const interleavedStruct = new RedGPU.Resource.VertexInterleavedStruct(
+            {
+                aVertexPosition: VC.float32x3,
+                aVertexNormal:   VC.float32x3,
+                aTexcoord:       VC.float32x2,
+                aTexcoord1:      VC.float32x2,
+                aVertexColor_0:  VC.float32x4,
+                aVertexTangent:  VC.float32x4,
+            },
+            'PBR'
         );
 
-        let geometry = new RedGPU.Geometry(
-            this,
-            new RedGPU.Buffer(
-                this,
-                'interleaveBuffer',
-                RedGPU.Buffer.TYPE_VERTEX,
-                new Float32Array(interleaveData),
-                [
-                    new RedGPU.InterleaveInfo('vertexPosition', 'float32x3'),
-                    new RedGPU.InterleaveInfo('vertexColor', 'float32x4')
-                ]
-            ),
-            new RedGPU.Buffer(
-                this,
-                'indexBuffer',
-                RedGPU.Buffer.TYPE_INDEX,
-                new Uint32Array(indexData)
-            )
+        // 24 vertices (6 faces x 4), one color per face.
+        // position(x,y,z)   normal(x,y,z)   uv   uv1   color(r,g,b,a)        tangent
+        const interleaveData = new Float32Array([
+            // Front face (red)
+            -0.5, -0.5,  0.5,   0, 0, 1,   0, 0,  0, 0,   1.0, 0.0, 0.0, 1.0,   1, 0, 0, 1,
+             0.5, -0.5,  0.5,   0, 0, 1,   0, 0,  0, 0,   1.0, 0.0, 0.0, 1.0,   1, 0, 0, 1,
+             0.5,  0.5,  0.5,   0, 0, 1,   0, 0,  0, 0,   1.0, 0.0, 0.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5,  0.5,   0, 0, 1,   0, 0,  0, 0,   1.0, 0.0, 0.0, 1.0,   1, 0, 0, 1,
+            // Back face (yellow)
+            -0.5, -0.5, -0.5,   0, 0,-1,   0, 0,  0, 0,   1.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+             0.5, -0.5, -0.5,   0, 0,-1,   0, 0,  0, 0,   1.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+             0.5,  0.5, -0.5,   0, 0,-1,   0, 0,  0, 0,   1.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5, -0.5,   0, 0,-1,   0, 0,  0, 0,   1.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+            // Top face (green)
+             0.5,  0.5,  0.5,   0, 1, 0,   0, 0,  0, 0,   0.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5,  0.5,   0, 1, 0,   0, 0,  0, 0,   0.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5, -0.5,   0, 1, 0,   0, 0,  0, 0,   0.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+             0.5,  0.5, -0.5,   0, 1, 0,   0, 0,  0, 0,   0.0, 1.0, 0.0, 1.0,   1, 0, 0, 1,
+            // Bottom face (pink)
+            -0.5, -0.5,  0.5,   0,-1, 0,   0, 0,  0, 0,   1.0, 0.5, 0.5, 1.0,   1, 0, 0, 1,
+             0.5, -0.5,  0.5,   0,-1, 0,   0, 0,  0, 0,   1.0, 0.5, 0.5, 1.0,   1, 0, 0, 1,
+             0.5, -0.5, -0.5,   0,-1, 0,   0, 0,  0, 0,   1.0, 0.5, 0.5, 1.0,   1, 0, 0, 1,
+            -0.5, -0.5, -0.5,   0,-1, 0,   0, 0,  0, 0,   1.0, 0.5, 0.5, 1.0,   1, 0, 0, 1,
+            // Right face (magenta)
+             0.5, -0.5,  0.5,   1, 0, 0,   0, 0,  0, 0,   1.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+             0.5,  0.5,  0.5,   1, 0, 0,   0, 0,  0, 0,   1.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+             0.5,  0.5, -0.5,   1, 0, 0,   0, 0,  0, 0,   1.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+             0.5, -0.5, -0.5,   1, 0, 0,   0, 0,  0, 0,   1.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+            // Left face (blue)
+            -0.5, -0.5,  0.5,  -1, 0, 0,   0, 0,  0, 0,   0.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5,  0.5,  -1, 0, 0,   0, 0,  0, 0,   0.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+            -0.5,  0.5, -0.5,  -1, 0, 0,   0, 0,  0, 0,   0.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+            -0.5, -0.5, -0.5,  -1, 0, 0,   0, 0,  0, 0,   0.0, 0.0, 1.0, 1.0,   1, 0, 0, 1,
+        ]);
+        const indexData = new Uint32Array([
+             0,  1,  2,    0,  2,  3, // Front
+             4,  5,  6,    4,  6,  7, // Back
+             8,  9, 10,    8, 10, 11, // Top
+            12, 13, 14,   12, 14, 15, // Bottom
+            16, 17, 18,   16, 18, 19, // Right
+            20, 21, 22,   20, 22, 23, // Left
+        ]);
+
+        const geometry = new RedGPU.Geometry(
+            redGPUContext,
+            new RedGPU.Resource.VertexBuffer(redGPUContext, interleaveData, interleavedStruct),
+            new RedGPU.Resource.IndexBuffer(redGPUContext, indexData)
         );
 
-        let colorMat = new VertexColorMaterial(this);
-        let tMesh = new RedGPU.Mesh(this, geometry, colorMat);
-        tMesh.cullMode = 'none';
-        tScene.addChild(tMesh);
+        // Unlit + vertex color => the fragment outputs the interpolated vertex color
+        // directly, so each face shows its assigned solid color without lighting.
+        const material = new RedGPU.Material.PBRMaterial(redGPUContext);
+        material.useVertexColor = true;
+        material.useKHR_materials_unlit = true;
 
-        let renderer = new RedGPU.Render();
-        let render = (time) => {
-            tMesh.rotationX += 1;
-            tMesh.rotationY += 1;
-            tMesh.rotationZ += 1;
-            renderer.render(time, this);
-            requestAnimationFrame(render);
-        };
-        requestAnimationFrame(render);
+        const mesh = new RedGPU.Display.Mesh(redGPUContext, geometry, material);
+        mesh.primitiveState.cullMode = RedGPU.GPU_CULL_MODE.NONE;
+        scene.addChild(mesh);
+
+        const renderer = new RedGPU.Renderer(redGPUContext);
+        renderer.start(redGPUContext, () => {
+            mesh.rotationX += 0.5;
+            mesh.rotationY += 0.5;
+            mesh.rotationZ += 0.5;
+        });
+    },
+    (failReason) => {
+        console.error('Initialization failed:', failReason);
     }
-)
+);

--- a/examples/redgpu/square/index.js
+++ b/examples/redgpu/square/index.js
@@ -1,124 +1,77 @@
-import RedGPU from "https://redcamel.github.io/RedGPU/src/RedGPU.js";
+import * as RedGPU from "https://redcamel.github.io/RedGPU/dist/index.js";
 
-const c = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
+canvas.width = 512;
+canvas.height = 512;
 
-class VertexColorMaterial extends RedGPU.BaseMaterial {
-    static vertexShaderGLSL = `
-    #version 460
-    ${RedGPU.ShareGLSL.GLSL_SystemUniforms_vertex.systemUniforms}
-    ${RedGPU.ShareGLSL.GLSL_SystemUniforms_vertex.meshUniforms}
-    layout(location = 0) in vec3 position;
-    layout(location = 1) in vec4 vertexColor;
-    layout(location = 0) out vec4 vVertexColor;
-    void main() {
-        gl_Position = systemUniforms.perspectiveMTX * systemUniforms.cameraMTX * meshMatrixUniforms.modelMatrix[ int(meshUniforms.index) ] * vec4(position, 1.0);
-        vVertexColor = vertexColor;
-    }
-    `;
-    static fragmentShaderGLSL = `
-    #version 460
-    layout(location = 0) in vec4 vVertexColor;
-    layout(location = 0) out vec4 outColor;
-    layout(location = 1) out vec4 out_MouseColorID_Depth;
-    void main() {
-        outColor = vVertexColor;
-    }
-    `;
-    static PROGRAM_OPTION_LIST = {
-        vertex: [],
-        fragment: []
-    };
-    static uniformsBindGroupLayoutDescriptor_material = {
-        entries: []
-    };
-    static uniformBufferDescriptor_vertex = RedGPU.BaseMaterial.uniformBufferDescriptor_empty;
-    static uniformBufferDescriptor_fragment = RedGPU.BaseMaterial.uniformBufferDescriptor_empty;
+RedGPU.init(
+    canvas,
+    (redGPUContext) => {
+        const controller = new RedGPU.Camera.OrbitController(redGPUContext);
+        controller.distance = 5;
+        controller.tilt = 0;
 
-    constructor(redGPU) {
-        super(redGPU);
-        this.resetBindingInfo()
-    }
+        const scene = new RedGPU.Display.Scene();
+        const view = new RedGPU.Display.View3D(redGPUContext, scene, controller);
+        redGPUContext.addView(view);
 
-    resetBindingInfo() {
-        this.entries = [];
-        this._afterResetBindingInfo();
-    }
-}
-
-new RedGPU.RedGPUContext(c,
-    function () {
-        let tScene = new RedGPU.Scene();
-        tScene.backgroundColor = '#fff';
-
-        let tCamera = new RedGPU.ObitController(this);
-        let tView = new RedGPU.View(this, tScene, tCamera);
-        this.addView(tView);
-        tCamera.distance = 2;
-        tCamera.tilt = 0;
-
-        this.setSize(window.innerWidth, window.innerHeight);
-
-        // Square data
-        //             1.0 y
-        //              ^  -1.0
-        //              | / z
-        //              |/       x
-        // -1.0 -----------------> +1.0
-        //            / |
-        //      +1.0 /  |
-        //           -1.0
+        // Square data (XY plane, faces +Z toward the camera)
         //
         //        [0]------[1]
-        //         |      / |
-        //         |    /   |
-        //         |  /     |
+        //         | \      |
+        //         |   \    |
+        //         |     \  |
         //        [2]------[3]
         //
-        let interleaveData = new Float32Array(
-            [
-                // x,   y,   z,    r,   g,   b    a
-                -0.5,  0.5, 0.0,  1.0, 0.0, 0.0, 1.0, // v0
-                 0.5,  0.5, 0.0,  0.0, 1.0, 0.0, 1.0, // v1
-                -0.5, -0.5, 0.0,  0.0, 0.0, 1.0, 1.0, // v2
-                 0.5, -0.5, 0.0,  1.0, 1.0, 0.0, 1.0  // v3
-            ]
-        );
-        let indexData = new Uint32Array(
-            [
-                2, 1, 0, // v2-v1-v0
-                2, 3, 1  // v2-v3-v1
-            ]
-        );
-
-        let geometry = new RedGPU.Geometry(
-            this,
-            new RedGPU.Buffer(
-                this,
-                'interleaveBuffer',
-                RedGPU.Buffer.TYPE_VERTEX,
-                new Float32Array(interleaveData),
-                [
-                    new RedGPU.InterleaveInfo('vertexPosition', 'float32x3'),
-                    new RedGPU.InterleaveInfo('vertexColor', 'float32x4')
-                ]
-            ),
-            new RedGPU.Buffer(
-                this,
-                'indexBuffer',
-                RedGPU.Buffer.TYPE_INDEX,
-                new Uint32Array(indexData)
-            )
+        // RedGPU passes a per-vertex color (vertexColor_0) to the fragment shader
+        // only through the PBR vertex path, which is selected when the geometry's
+        // interleaved struct is labeled 'PBR'. So we build a full PBR vertex layout
+        // (position / normal / uv / uv1 / color / tangent) and feed per-vertex colors.
+        const VC = RedGPU.Resource.VertexInterleaveType;
+        const interleavedStruct = new RedGPU.Resource.VertexInterleavedStruct(
+            {
+                aVertexPosition: VC.float32x3,
+                aVertexNormal:   VC.float32x3,
+                aTexcoord:       VC.float32x2,
+                aTexcoord1:      VC.float32x2,
+                aVertexColor_0:  VC.float32x4,
+                aVertexTangent:  VC.float32x4,
+            },
+            'PBR'
         );
 
-        let colorMat = new VertexColorMaterial(this);
-        let tMesh = new RedGPU.Mesh(this, geometry, colorMat);
-        tScene.addChild(tMesh);
+        // position(x,y,z)   normal(x,y,z)  uv(u,v)  uv1(u,v)  color(r,g,b,a)   tangent(x,y,z,w)
+        const interleaveData = new Float32Array([
+            -1.0,  1.0, 0.0,   0, 0, 1,   0, 0,   0, 0,   1.0, 0.0, 0.0, 1.0,   1, 0, 0, 1, // v0 red
+             1.0,  1.0, 0.0,   0, 0, 1,   1, 0,   0, 0,   0.0, 1.0, 0.0, 1.0,   1, 0, 0, 1, // v1 green
+            -1.0, -1.0, 0.0,   0, 0, 1,   0, 1,   0, 0,   0.0, 0.0, 1.0, 1.0,   1, 0, 0, 1, // v2 blue
+             1.0, -1.0, 0.0,   0, 0, 1,   1, 1,   0, 0,   1.0, 1.0, 0.0, 1.0,   1, 0, 0, 1, // v3 yellow
+        ]);
+        const indexData = new Uint32Array([
+            2, 1, 0, // v2-v1-v0
+            2, 3, 1, // v2-v3-v1
+        ]);
 
-        let renderer = new RedGPU.Render();
-        let render = (time) => {
-            renderer.render(time, this);
-            requestAnimationFrame(render);
-        };
-        requestAnimationFrame(render);
+        const geometry = new RedGPU.Geometry(
+            redGPUContext,
+            new RedGPU.Resource.VertexBuffer(redGPUContext, interleaveData, interleavedStruct),
+            new RedGPU.Resource.IndexBuffer(redGPUContext, indexData)
+        );
+
+        // Unlit + vertex color => the fragment outputs the interpolated vertex color
+        // directly, giving a pure gradient without any lighting.
+        const material = new RedGPU.Material.PBRMaterial(redGPUContext);
+        material.useVertexColor = true;
+        material.useKHR_materials_unlit = true;
+
+        const mesh = new RedGPU.Display.Mesh(redGPUContext, geometry, material);
+        mesh.primitiveState.cullMode = RedGPU.GPU_CULL_MODE.NONE;
+        scene.addChild(mesh);
+
+        const renderer = new RedGPU.Renderer(redGPUContext);
+        renderer.start(redGPUContext, () => {});
+    },
+    (failReason) => {
+        console.error('Initialization failed:', failReason);
     }
-)
+);

--- a/examples/redgpu/teapot/index.html
+++ b/examples/redgpu/teapot/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>[WIP] Testing WebGPU Teapot Using RedGPU</title>
     <link rel="stylesheet" type="text/css" href="style.css">
-    <script src="https://code.jquery.com/jquery-3.4.0.js"></script>
   </head>
 <body>
 <canvas id="canvas"></canvas>

--- a/examples/redgpu/teapot/index.js
+++ b/examples/redgpu/teapot/index.js
@@ -1,87 +1,86 @@
-import RedGPU from "https://redcamel.github.io/RedGPU/src/RedGPU.js";
+import * as RedGPU from "https://redcamel.github.io/RedGPU/dist/index.js";
 
-const c = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
+canvas.width = 512;
+canvas.height = 512;
 
-let redGPU;
-new RedGPU.RedGPUContext(c,
-    function () {
-        redGPU = this;
-        let tScene = new RedGPU.Scene();
-        tScene.backgroundColor = '#000';
-        
-        let tCamera = new RedGPU.ObitController(this);
-        let tView = new RedGPU.View(this, tScene, tCamera);
-        this.addView(tView);
-        tCamera.distance = 40;
-        let tLight = new RedGPU.DirectionalLight(this);
-        tLight.x = 10;
-        tLight.y = 10;
-        tLight.z = 10;
-        tScene.addLight(tLight)
-        this.setSize(window.innerWidth, window.innerHeight);
+RedGPU.init(
+    canvas,
+    (redGPUContext) => {
+        const controller = new RedGPU.Camera.OrbitController(redGPUContext);
+        controller.distance = 40;
+        controller.tilt = -10;
 
-        let interleaveData;
-        let indexData;
+        const scene = new RedGPU.Display.Scene();
+        scene.useBackgroundColor = true;
+        scene.backgroundColor.setColorByHEX('#000000');
+
+        const view = new RedGPU.Display.View3D(redGPUContext, scene, controller);
+        redGPUContext.addView(view);
 
         // copy from: https://github.com/gpjt/webgl-lessons/blob/master/lesson14/Teapot.json
-        $.getJSON("../../../assets/json/teapot.json", function (data) {
+        fetch('../../../assets/json/teapot.json')
+            .then((response) => response.json())
+            .then((data) => {
+                const vertexPositions = data.vertexPositions;
+                const vertexTextureCoords = data.vertexTextureCoords;
+                const vertexNormals = data.vertexNormals;
+                const indices = data.indices;
 
-            let vertexPositions = data.vertexPositions;
-            let vertexTextureCoords = data.vertexTextureCoords;
-            let vertexNormals = data.vertexNormals;
-            let indices = data.indices;
+                // BitmapMaterial uses the basic (non-PBR) vertex path, whose input is
+                // position / normal / uv / tangent. The teapot model has no tangents,
+                // so a dummy tangent is supplied (BitmapMaterial does not use it).
+                const interleaveDataBuffer = [];
+                const len = vertexPositions.length / 3;
+                for (let i = 0; i < len; i++) {
+                    interleaveDataBuffer.push(
+                        vertexPositions[i * 3 + 0],
+                        vertexPositions[i * 3 + 1],
+                        vertexPositions[i * 3 + 2],
+                        vertexNormals[i * 3 + 0],
+                        vertexNormals[i * 3 + 1],
+                        vertexNormals[i * 3 + 2],
+                        vertexTextureCoords[i * 2 + 0],
+                        vertexTextureCoords[i * 2 + 1],
+                        1, 0, 0, 1 // tangent (unused by BitmapMaterial)
+                    );
+                }
 
-            let interleaveDataBuffer = [];
-            let len = vertexPositions.length / 3;
-            for (let i = 0; i < len; i++ ) {
-                interleaveDataBuffer.push(vertexPositions[i*3+0]);
-                interleaveDataBuffer.push(vertexPositions[i*3+1]);
-                interleaveDataBuffer.push(vertexPositions[i*3+2]);
-                interleaveDataBuffer.push(vertexNormals[i*3+0]);
-                interleaveDataBuffer.push(vertexNormals[i*3+1]);
-                interleaveDataBuffer.push(vertexNormals[i*3+2]);
-                interleaveDataBuffer.push(vertexTextureCoords[i*2+0]);
-                interleaveDataBuffer.push(vertexTextureCoords[i*2+1]);
-            }
-            interleaveData = new Float32Array(interleaveDataBuffer);
-            indexData = new Uint16Array(indices);
+                const VC = RedGPU.Resource.VertexInterleaveType;
+                const interleavedStruct = new RedGPU.Resource.VertexInterleavedStruct({
+                    vertexPosition: VC.float32x3,
+                    vertexNormal:   VC.float32x3,
+                    texcoord:       VC.float32x2,
+                    vertexTangent:  VC.float32x4,
+                });
 
-            let geometry = new RedGPU.Geometry(
-                redGPU,
-                new RedGPU.Buffer(
-                    redGPU,
-                    'interleaveBuffer',
-                    RedGPU.Buffer.TYPE_VERTEX,
-                    new Float32Array(interleaveData),
-                    [
-                        new RedGPU.InterleaveInfo('vertexPosition', 'float32x3'),
-                        new RedGPU.InterleaveInfo('vertexNormal', 'float32x3'),
-                        new RedGPU.InterleaveInfo('texcoord', 'float32x2')
-                    ]
-                ),
-                new RedGPU.Buffer(
-                    redGPU,
-                    'indexBuffer',
-                    RedGPU.Buffer.TYPE_INDEX,
-                    new Uint32Array(indexData)
-                )
-            );
-            // copy from: https://github.com/gpjt/webgl-lessons/blob/master/lesson14/arroway.de_metal%2Bstructure%2B06_d100_flat.jpg
-            let texture = new RedGPU.BitmapTexture(redGPU, '../../../assets/textures/arroway.de_metal+structure+06_d100_flat.jpg');
-            let material  = new RedGPU.BitmapMaterial(redGPU, texture);
-            let tMesh = new RedGPU.Mesh(redGPU, geometry, material);
-            tScene.addChild(tMesh);
+                const geometry = new RedGPU.Geometry(
+                    redGPUContext,
+                    new RedGPU.Resource.VertexBuffer(redGPUContext, new Float32Array(interleaveDataBuffer), interleavedStruct),
+                    new RedGPU.Resource.IndexBuffer(redGPUContext, new Uint32Array(indices))
+                );
 
-            let renderer = new RedGPU.Render();
-            let render = function (time) {
-                //tMesh.rotationX += 1;
-                tMesh.rotationY += 1;
-                //tMesh.rotationZ += 1;
-                renderer.render(time, redGPU);
-                requestAnimationFrame(render);
-            };
+                // copy from: https://github.com/gpjt/webgl-lessons/blob/master/lesson14/arroway.de_metal%2Bstructure%2B06_d100_flat.jpg
+                const texture = new RedGPU.Resource.BitmapTexture(redGPUContext, '../../../assets/textures/arroway.de_metal+structure+06_d100_flat.jpg');
+                const material = new RedGPU.Material.BitmapMaterial(redGPUContext, texture);
+                // The teapot UVs tile the texture (values exceed 0..1), so the sampler
+                // must wrap with 'repeat' instead of the default clamp-to-edge, which
+                // would stretch the edge texels across the body.
+                material.diffuseTextureSampler = new RedGPU.Resource.Sampler(redGPUContext, {
+                    addressModeU: 'repeat',
+                    addressModeV: 'repeat',
+                });
 
-            requestAnimationFrame(render);
-        });
+                const mesh = new RedGPU.Display.Mesh(redGPUContext, geometry, material);
+                scene.addChild(mesh);
+
+                const renderer = new RedGPU.Renderer(redGPUContext);
+                renderer.start(redGPUContext, () => {
+                    mesh.rotationY += 0.5;
+                });
+            });
+    },
+    (failReason) => {
+        console.error('Initialization failed:', failReason);
     }
 );

--- a/examples/redgpu/texture/index.js
+++ b/examples/redgpu/texture/index.js
@@ -1,118 +1,43 @@
-import RedGPU from "https://redcamel.github.io/RedGPU/src/RedGPU.js";
+import * as RedGPU from "https://redcamel.github.io/RedGPU/dist/index.js";
 
-const c = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
+canvas.width = 512;
+canvas.height = 512;
 
-new RedGPU.RedGPUContext(c,
-    function () {
-        let tScene = new RedGPU.Scene();
-        tScene.backgroundColor = '#fff';
+RedGPU.init(
+    canvas,
+    (redGPUContext) => {
+        const controller = new RedGPU.Camera.OrbitController(redGPUContext);
+        controller.distance = 3;
+        controller.tilt = -20;
 
-        let tCamera = new RedGPU.ObitController(this);
-        let tView = new RedGPU.View(this, tScene, tCamera);
-        this.addView(tView);
-        tCamera.distance = 2;
+        const scene = new RedGPU.Display.Scene();
+        scene.useBackgroundColor = true;
+        scene.backgroundColor.setColorByHEX('#ffffff');
 
-        this.setSize(window.innerWidth, window.innerHeight);
+        const view = new RedGPU.Display.View3D(redGPUContext, scene, controller);
+        redGPUContext.addView(view);
 
-        // Cube data
-        //             1.0 y
-        //              ^  -1.0
-        //              | / z
-        //              |/       x
-        // -1.0 -----------------> +1.0
-        //            / |
-        //      +1.0 /  |
-        //           -1.0
-        //
-        //         [7]------[6]
-        //        / |      / |
-        //      [3]------[2] |
-        //       |  |     |  |
-        //       | [4]----|-[5]
-        //       |/       |/
-        //      [0]------[1]
-        //
-        let interleaveData = new Float32Array(
-            [
-                // Front face
-                -0.5, -0.5,  0.5,    0.0,  0.0,  1.0,   0.0, 0.0, // v0
-                 0.5, -0.5,  0.5,    0.0,  0.0,  1.0,   1.0, 0.0, // v1
-                 0.5,  0.5,  0.5,    0.0,  0.0,  1.0,   1.0, 1.0, // v2
-                -0.5,  0.5,  0.5,    0.0,  0.0,  1.0,   0.0, 1.0, // v3
-                // Back face
-                -0.5, -0.5, -0.5,    0.0,  0.0, -1.0,   1.0, 0.0, // v4
-                 0.5, -0.5, -0.5,    0.0,  0.0, -1.0,   1.0, 1.0, // v5
-                 0.5,  0.5, -0.5,    0.0,  0.0, -1.0,   0.0, 1.0, // v6
-                -0.5,  0.5, -0.5,    0.0,  0.0, -1.0,   0.0, 0.0, // v7
-                // Top face
-                 0.5,  0.5,  0.5,    0.0,  1.0,  0.0,   0.0, 1.0, // v2
-                -0.5,  0.5,  0.5,    0.0,  1.0,  0.0,   0.0, 0.0, // v3
-                -0.5,  0.5, -0.5,    0.0,  1.0,  0.0,   1.0, 0.0, // v7
-                 0.5,  0.5, -0.5,    0.0,  1.0,  0.0,   1.0, 1.0, // v6
-                // Bottom face
-                -0.5, -0.5,  0.5,    0.0,  1.5,  0.0,   1.0, 1.0, // v0
-                 0.5, -0.5,  0.5,    0.0,  1.5,  0.0,   0.0, 1.0, // v1
-                 0.5, -0.5, -0.5,    0.0,  1.5,  0.0,   0.0, 0.0, // v5
-                -0.5, -0.5, -0.5,    0.0,  1.5,  0.0,   1.0, 0.0, // v4
-                // Right face
-                 0.5, -0.5,  0.5,    1.0,  0.0,  0.0,   1.0, 0.0, // v1
-                 0.5,  0.5,  0.5,    1.0,  0.0,  0.0,   1.0, 1.0, // v2
-                 0.5,  0.5, -0.5,    1.0,  0.0,  0.0,   0.0, 1.0, // v6
-                 0.5, -0.5, -0.5,    1.0,  0.0,  0.0,   0.0, 0.0, // v5
-                // Left face
-                -0.5, -0.5,  0.5,   -1.0,  0.0,  0.0,   0.0, 0.0, // v0
-                -0.5,  0.5,  0.5,   -1.0,  0.0,  0.0,   1.0, 0.0, // v3
-                -0.5,  0.5, -0.5,   -1.0,  0.0,  0.0,   1.0, 1.0, // v7
-                -0.5, -0.5, -0.5,   -1.0,  0.0,  0.0,   0.0, 1.0  // v4
-            ]
-        );
-        let indexData = new Uint32Array(
-            [
-                0,  1,  2,    0,  2 , 3,  // Front face
-                4,  5,  6,    4,  6 , 7,  // Back face
-                8,  9, 10,    8, 10, 11,  // Top face
-                12, 13, 14,   12, 14, 15,  // Bottom face
-                16, 17, 18,   16, 18, 19,  // Right face
-                20, 21, 22,   20, 22, 23   // Left face
-            ]
-        );
+        // Box primitive already provides per-face UVs, so a BitmapMaterial maps the
+        // texture onto every face. BitmapMaterial is unlit (it outputs the sampled
+        // texture color directly), matching the original sample.
+        const geometry = new RedGPU.Primitive.Box(redGPUContext, 1, 1, 1);
 
-        let geometry = new RedGPU.Geometry(
-            this,
-            new RedGPU.Buffer(
-                this,
-                'interleaveBuffer',
-                RedGPU.Buffer.TYPE_VERTEX,
-                new Float32Array(interleaveData),
-                [
-                    new RedGPU.InterleaveInfo('vertexPosition', 'float32x3'),
-                    new RedGPU.InterleaveInfo('vertexNormal', 'float32x3'),
-                    new RedGPU.InterleaveInfo('texcoord', 'float32x2')
-                ]
-            ),
-            new RedGPU.Buffer(
-                this,
-                'indexBuffer',
-                RedGPU.Buffer.TYPE_INDEX,
-                new Uint32Array(indexData)
-            )
-        );
-        let texture = new RedGPU.BitmapTexture(this, 'https://cx20.github.io/webgpu-test/assets/textures/frog.jpg');
-        let textureMat = new RedGPU.BitmapMaterial(this, texture);
-        let tMesh = new RedGPU.Mesh(this, geometry, textureMat);
-        tMesh.cullMode = 'none';
-        tScene.addChild(tMesh);
+        const texture = new RedGPU.Resource.BitmapTexture(redGPUContext, '../../../assets/textures/frog.jpg');
+        const material = new RedGPU.Material.BitmapMaterial(redGPUContext, texture);
 
-        let renderer = new RedGPU.Render();
-        let render =  (time)=> {
-            tMesh.rotationX += 1;
-            tMesh.rotationY += 1;
-            tMesh.rotationZ += 1;
-            renderer.render(time, this);
-            requestAnimationFrame(render);
-        };
-        requestAnimationFrame(render);
+        const mesh = new RedGPU.Display.Mesh(redGPUContext, geometry, material);
+        mesh.primitiveState.cullMode = RedGPU.GPU_CULL_MODE.NONE;
+        scene.addChild(mesh);
 
-
+        const renderer = new RedGPU.Renderer(redGPUContext);
+        renderer.start(redGPUContext, () => {
+            mesh.rotationX += 0.5;
+            mesh.rotationY += 0.5;
+            mesh.rotationZ += 0.5;
+        });
+    },
+    (failReason) => {
+        console.error('Initialization failed:', failReason);
     }
-)
+);

--- a/examples/redgpu/triangle/index.js
+++ b/examples/redgpu/triangle/index.js
@@ -7,7 +7,7 @@ canvas.height = 512;
 RedGPU.init(
     canvas,
     (redGPUContext) => {
-        const controller = new RedGPU.Camera.ObitController(redGPUContext);
+        const controller = new RedGPU.Camera.OrbitController(redGPUContext);
         controller.distance = 5;
         controller.tilt = 0;
 
@@ -20,7 +20,10 @@ RedGPU.init(
         const material = new RedGPU.Material.ColorMaterial(redGPUContext, "#0000ff");
 
         const mesh = new RedGPU.Display.Mesh(redGPUContext, geometry, material);
-        mesh.setRotation(0, 0, 30);
+        // Circle is generated on the XZ plane (normal +Y). Stand it up to face the
+        // camera (normal +Z) with one vertex pointing up. Rotation order is Ry*Rx*Rz.
+        mesh.setRotation(0, 90, 90);
+        mesh.primitiveState.cullMode = RedGPU.GPU_CULL_MODE.NONE;
         scene.addChild(mesh);
 
         const renderer = new RedGPU.Renderer(redGPUContext);


### PR DESCRIPTION
## Summary

RedGPU was rewritten and the old `src/RedGPU.js` API (`RedGPUContext`, `BaseMaterial`, GLSL shaders, `ObitController`, …) no longer exists, so all RedGPU samples had stopped working. This migrates every sample to the current `dist/index.js` API.

## Changes

- **triangle**: `ObitController` → `OrbitController` (the breaking rename). Also stand the `Circle` (generated on the XZ plane, normal +Y) upright with `setRotation(0, 90, 90)` so it faces the camera head-on.
- **square**: vertex-color gradient. RedGPU only passes `vertexColor_0` through the PBR vertex path, so the geometry is built with a `'PBR'`-labeled interleaved struct and rendered with `PBRMaterial` (`useVertexColor` + `useKHR_materials_unlit` → unlit).
- **cube**: per-face colors using the same vertex-color approach (front=red, back=yellow, top=green, bottom=pink, right=magenta, left=blue).
- **texture**: `Primitive.Box` + `BitmapMaterial` (frog.jpg).
- **teapot**: replace jQuery `$.getJSON` with `fetch`; build geometry from `teapot.json`; use a `repeat` sampler so the tiled body texture wraps correctly (default clamp-to-edge stretched the edge texels).
- Remove dead external `<script>` tags (gl-matrix / dat.gui / jQuery loaded from raw URLs that no longer execute).

## Test plan

Open each sample under `examples/redgpu/*` with a local server (e.g. Live Server) in a WebGPU-capable browser and confirm it renders:
- triangle: blue triangle, front-facing
- square: smooth corner gradient
- cube: rotating cube with 6 colored faces
- texture: rotating frog-textured cube
- teapot: rotating metal-textured teapot

🤖 Generated with [Claude Code](https://claude.com/claude-code)