### PR TITLE
redgpu: remove [WIP] from sample page titles

### DIFF
--- a/examples/redgpu/teapot/index.html
+++ b/examples/redgpu/teapot/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>[WIP] Testing WebGPU Teapot Using RedGPU</title>
+    <title>Testing WebGPU Teapot Using RedGPU</title>
     <link rel="stylesheet" type="text/css" href="style.css">
   </head>
 <body>

--- a/examples/redgpu/texture/index.html
+++ b/examples/redgpu/texture/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>[WIP] Testing WebGPU Textured Cube Using RedGPU</title>
+    <title>Testing WebGPU Textured Cube Using RedGPU</title>
     <link rel="stylesheet" type="text/css" href="style.css">
   </head>
 <body>

--- a/examples/redgpu/triangle/index.html
+++ b/examples/redgpu/triangle/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>[WIP] Testing WebGPU Triangle Using RedGPU</title>
+    <title>Testing WebGPU Triangle Using RedGPU</title>
     <link rel="stylesheet" type="text/css" href="style.css">
   </head>
 <body>


### PR DESCRIPTION
## Summary
- The RedGPU triangle, teapot, and texture samples are confirmed working, so the `[WIP]` prefix has been removed from the `<title>` tag of each `index.html`.

## Changes
- `examples/redgpu/triangle/index.html`
- `examples/redgpu/teapot/index.html`
- `examples/redgpu/texture/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)