### PR TITLE
Update Babylon Lite to v1.7.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
## Summary

- Bump `@babylonjs/lite` from `1.6.0` to `1.7.0` across all babylon-lite samples (complex, cube, primitive, square, teapot, texture, triangles). The `?bundle` query is preserved.

## Notes

No code changes required. The glTF loader animation defaults and the `playAnimation` / `stopAnimation` API are unchanged, so the Fox animation in the complex sample keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)