### PR TITLE
Update Babylon Lite to v1.9.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
Update Babylon Lite from v1.8.0 to v1.9.0 across all examples.

Changed the import map CDN URL from `https://esm.sh/@babylonjs/lite@1.8.0?bundle` to `https://esm.sh/@babylonjs/lite@1.9.0?bundle` in the following examples:

- triangles
- texture
- teapot
- square
- primitive
- cube
- complex

🤖 Generated with [Claude Code](https://claude.com/claude-code)