### PR TITLE
Update Babylon Lite to v1.10.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.9.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
Bump the `@babylonjs/lite` import map entry from 1.9.0 to 1.10.0 across all Babylon Lite samples (complex, cube, primitive, square, teapot, texture, triangles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)