### PR TITLE
Update Babylon Lite to v2.0.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
Bumps `@babylonjs/lite` from 1.10.0 to 2.0.0 in all 7 samples (import map only, 1 line per `index.html`).

## Breaking change assessment

v2.0.0 lists a single breaking change: **managed storage buffers**. Diffing the type definitions between 1.10.0 and 2.0.0, the only incompatible signature is:

```diff
-setShaderStorageBuffer(material, name, buffer: GPUBuffer | null)
+setShaderStorageBuffer(material, name, buffer: StorageBuffer | null)
```

None of the samples use storage buffers, so no code changes are required. Every other API difference is either purely additive (`createStorageBuffer`, `updateMeshGeometry`, VAT / thin-instance helpers) or a backward-compatible optional parameter (`updateMeshPositions` and friends). All 29 APIs the samples import have unchanged signatures.

## Verification

All 7 samples were loaded in Chrome 150 with a real WebGPU adapter and compared against 1.10.0 screenshots:

| Sample | Result |
| --- | --- |
| triangles, square | Pixel-identical to 1.10.0 |
| cube, texture, teapot, primitive, complex | Render correctly; differ only by animation phase |

No console errors on any sample. The `complex` sample still shows the skybox, T-Rex, Fox, delivery van, and the NPE tire dust particles as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)