### PR TITLE
Revert Babylon Lite to v1.10.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@2.0.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
## Summary

The `@babylonjs/lite` 2.0.0 package published on npm turned out to be an erroneous release, so this reverts the samples back to `1.10.0`.

- Wrong: `https://esm.sh/@babylonjs/lite@2.0.0?bundle`
- Correct: `https://esm.sh/@babylonjs/lite@1.10.0?bundle`

## Scope

This reverts only the importmap version strings across the 7 Babylon Lite samples (complex, cube, primitive, square, teapot, texture, triangles). Commit 091fcb8 (`Update Babylon Lite to v2.0.0`) contained no sample code changes, so the version-independent sample fixes remain intact — `examples/babylon-lite` is now identical to its state at 4f5d76b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)