### PR TITLE
Update Babylon Lite to 1.12.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.11.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.12.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
## Summary

- Update the Babylon Lite import map URL from version 1.11.0 to 1.12.0.
- Apply the update to all seven examples under `examples/babylon-lite`.

## Motivation

Keep the Babylon Lite examples aligned with the latest requested release.

## Impact

All Babylon Lite examples now load version 1.12.0 from esm.sh. No application logic was changed.

## Validation

- Confirmed there are no remaining `@babylonjs/lite@1.11.0` references under `examples`.
- Ran `git diff --check` successfully.
