### PR TITLE
Update Babylon Lite to 1.16.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.16.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
Update the `@babylonjs/lite` import map entry from 1.15.0 to 1.16.0 in all Babylon Lite examples.

- examples/babylon-lite/complex
- examples/babylon-lite/cube
- examples/babylon-lite/primitive
- examples/babylon-lite/square
- examples/babylon-lite/teapot
- examples/babylon-lite/texture
- examples/babylon-lite/triangles

🤖 Generated with [Claude Code](https://claude.com/claude-code)