### PR TITLE
Update Babylon Lite to 1.21.0

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle"
   }
 }
 </script>


### PR DESCRIPTION
Bump `@babylonjs/lite` from 1.19.0 to 1.21.0 in the importmap of all Babylon Lite examples.

Updated files:
- examples/babylon-lite/complex/index.html
- examples/babylon-lite/cube/index.html
- examples/babylon-lite/primitive/index.html
- examples/babylon-lite/square/index.html
- examples/babylon-lite/teapot/index.html
- examples/babylon-lite/texture/index.html
- examples/babylon-lite/triangles/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)