### PR TITLE
Load Babylon Lite from jsDelivr +esm instead of esm.sh ?bundle

### DIFF
--- a/examples/babylon-lite/complex/index.html
+++ b/examples/babylon-lite/complex/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/cube/index.html
+++ b/examples/babylon-lite/cube/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/primitive/index.html
+++ b/examples/babylon-lite/primitive/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/square/index.html
+++ b/examples/babylon-lite/square/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/teapot/index.html
+++ b/examples/babylon-lite/teapot/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/texture/index.html
+++ b/examples/babylon-lite/texture/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>

--- a/examples/babylon-lite/triangles/index.html
+++ b/examples/babylon-lite/triangles/index.html
@@ -10,7 +10,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.25.0?bundle"
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
   }
 }
 </script>


### PR DESCRIPTION
The Babylon Lite samples were loading 2024 KB of library per page - more than the full Babylon.js build (1750 KB), which defeats the point of the "lite" build.

## Cause

Babylon Lite keeps its core small and pulls features in through **327 dynamic imports**. esm.sh's `?bundle` inlines every one of them statically, so each page also downloaded the recast-navigation (2.1 MB raw), manifold (1.5 MB) and text-shaper (0.7 MB) vendor chunks that no sample touches.

esm.sh also compresses that file poorly: its brotli response (2024 KB) was larger than its own gzip response (1631 KB).

## Change

The importmap now points at jsDelivr's `+esm` build, which keeps the dynamic imports lazy:

```
"@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.25.0/+esm"
```

A page loads the 450 KB core plus only the chunks it uses - 1 chunk (6.5 KB) for the ShaderMaterial samples, 2 (11 KB) for the StandardMaterial ones, 18 for complex.

## Measured transfer per page

Chrome, CDP `encodedDataLength` (real bytes on the wire):

| sample | before | after |
| --- | ---: | ---: |
| triangles | 2025 KB | 460 KB |
| square | 2025 KB | 460 KB |
| cube | 2025 KB | 462 KB |
| texture | 2045 KB | 484 KB |
| teapot | 2147 KB | 630 KB |
| primitive | 2229 KB | 669 KB |

Library only: 2024 KB / 6 requests -> 450 KB + 6-11 KB of chunks / 1-3 requests (-77%).

## Verification

All seven samples were run in headless Chrome 151 with WebGPU enabled (`requestAdapter` returns an adapter), before and after the change:

- Every sample renders the same as before - ShaderMaterial, StandardMaterial with textures, directional light, ArcRotateCamera, and complex with its three glTF models, animations, skybox, environment and particles.
- No console errors, page errors or failed requests in either mode.
- Time to first paint is unchanged: triangles 387 -> 318 ms, primitive ~680 ms in both, complex 2769 -> 2518 ms. The library response itself arrives sooner (about 130 ms vs 190 ms), which offsets the extra chunk round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)