### PR TITLE
Fix Babylon.js triangle, square, cube and texture samples

### DIFF
--- a/examples/babylonjs/cube/index.js
+++ b/examples/babylonjs/cube/index.js
@@ -7,7 +7,7 @@ async function init() {
         const scene = new BABYLON.Scene(engine);
         const camera = new BABYLON.FreeCamera("camera", new BABYLON.Vector3(0, 0, -3), scene);
         scene.clearColor = new BABYLON.Color3(1, 1, 1);
-        const cube = new BABYLON.Mesh.CreateBox('cube', 1.0, scene);
+        const cube = BABYLON.Mesh.CreateBox('cube', 1.0, scene);
         const colors = [
                 1.0, 0.0, 0.0, 1.0, // Front face
                 1.0, 0.0, 0.0, 1.0, // Front face

--- a/examples/babylonjs/square/index.js
+++ b/examples/babylonjs/square/index.js
@@ -7,7 +7,7 @@ async function init() {
         const scene = new BABYLON.Scene(engine);
         const camera = new BABYLON.FreeCamera("camera", new BABYLON.Vector3(0, 0, -2.4), scene);
         scene.clearColor = new BABYLON.Color3(1, 1, 1);
-        const square = new BABYLON.Mesh.CreatePlane('square', 1.0, scene);
+        const square = BABYLON.Mesh.CreatePlane('square', 1.0, scene);
         const colors = [
             0.0, 0.0, 1.0, 1.0,
             1.0, 1.0, 0.0, 1.0,

--- a/examples/babylonjs/texture/index.js
+++ b/examples/babylonjs/texture/index.js
@@ -7,7 +7,7 @@ async function init() {
         const scene = new BABYLON.Scene(engine);
         const camera = new BABYLON.FreeCamera("camera", new BABYLON.Vector3(0, 0, -3), scene);
         scene.clearColor = new BABYLON.Color3(1, 1, 1);
-        const cube = new BABYLON.Mesh.CreateBox('cube', 1.0, scene);
+        const cube = BABYLON.Mesh.CreateBox('cube', 1.0, scene);
         const material = new BABYLON.StandardMaterial("material", scene);
         material.diffuseTexture = new BABYLON.Texture("../../../assets/textures/frog.jpg", scene);
         material.emissiveColor = new BABYLON.Color3(1, 1, 1);

--- a/examples/babylonjs/triangle/index.js
+++ b/examples/babylonjs/triangle/index.js
@@ -13,7 +13,7 @@ async function init() {
         points.push( new BABYLON.Vector3( 0.5, -0.5, 0.0 ) );
         points.push( new BABYLON.Vector3( 0.0,  0.5, 0.0 ) );
 
-        const triangle = new BABYLON.Mesh.CreateLines('triangle', points, scene);
+        const triangle = BABYLON.Mesh.CreateLines('triangle', points, scene);
         triangle.color = new BABYLON.Color3(0, 0, 1);
 
         return scene;


### PR DESCRIPTION
The Babylon.js triangle, square, cube and texture samples currently render a blank canvas on the live site. Each one dies at startup:

```
Uncaught TypeError: BABYLON.Mesh.CreateBox is not a constructor
```

## Cause

`BABYLON.Mesh.CreateBox` / `CreatePlane` / `CreateLines` are plain factory functions, but these four samples called them with `new`. That used to work, because `new f()` returns `f`'s return value when it returns an object. In the current build (v9.19.1) these are defined in a way that is not constructible, so the call throws before anything is drawn.

The primitive and complex samples already call the same factories without `new` and were unaffected.

## Change

Removed the `new` keyword - one line per sample, no other change.

## Verification

Run in Chrome 151 with WebGPU enabled, before and after:

| sample | before | after |
| --- | --- | --- |
| triangle | blank canvas, `CreateLines is not a constructor` | blue triangle outline |
| square | blank canvas, `CreatePlane is not a constructor` | vertex-coloured square |
| cube | blank canvas, `CreateBox is not a constructor` | coloured rotating cube |
| texture | blank canvas, `CreateBox is not a constructor` | frog-textured rotating cube |

No console errors remain. The babylonjs_wgsl samples and the Babylon.js primitive/complex samples were checked too and were already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)